### PR TITLE
vector_ket for Thrust

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,15 +8,13 @@
 
 # Generic rule for the repository. This pattern is actually the one that will
 # apply unless specialized by a later rule
-* @chriseclectic @vvilpas @atilag
+* @chriseclectic @vvilpas
 
 # Individual folders on root directory
-/qiskit         @chriseclectic @atilag @vvilpas
-/cmake          @atilag @vvilpas
-/doc            @chriseclectic @atilag @vvilpas
-/examples       @chriseclectic @atilag @vvilpas
-/contrib        @chriseclectic @atilag @vvilpas
-/test           @chriseclectic @atilag @vvilpas
-/src            @chriseclectic @atilag @vvilpas
-
-# AER specific folders
+/qiskit         @chriseclectic @vvilpas @mtreinish
+/test           @chriseclectic @vvilpas @mtreinish
+/doc            @chriseclectic @vvilpas @mtreinish
+/releasenotes   @chriseclectic @vvilpas @mtreinish
+/cmake          @vvilpas
+/contrib        @chriseclectic @vvilpas @hhorii
+/src            @chriseclectic @vvilpas @hhorii

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
 # Contributing
 
 First read the overall project contributing guidelines. These are all
-included in the qiskit documentation:
+included in the Qiskit documentation:
 
 https://qiskit.org/documentation/contributing_to_qiskit.html
 
 ## Contributing to Qiskit Aer
 
-In addition to the general guidelines there are specific details for
-contributing to aer, these are documented below.
+In addition to the general guidelines, there are specific details for
+contributing to Aer. These are documented below.
 
 ### Pull request checklist
 
@@ -23,21 +23,21 @@ please ensure that:
    *docstring* accordingly.
 3. If it makes sense for your change that you have added new tests that
    cover the changes.
-4. Ensure that if your change has an end user facing impact (new feature,
-   deprecation, removal etc) that you have added a reno release note for that
+4. Ensure that if your change has an enduser-facing impact (new feature,
+   deprecation, removal, etc.), you have added a reno release note for that
    change and that the PR is tagged for the changelog.
 
 ### Changelog generation
 
 The changelog is automatically generated as part of the release process
 automation. This works through a combination of the git log and the pull
-request. When a release is tagged and pushed to github the release automation
+request. When a release is tagged and pushed to GitHub, the release automation
 bot looks at all commit messages from the git log for the release. It takes the
 PR numbers from the git log (assuming a squash merge) and checks if that PR had
 a `Changelog:` label on it. If there is a label it will add the git commit
 message summary line from the git log for the release to the changelog.
 
-If there are multiple `Changelog:` tags on a PR the git commit message summary
+If there are multiple `Changelog:` tags on a PR, the git commit message summary
 line from the git log will be used for each changelog category tagged.
 
 The current categories for each label are as follows:
@@ -52,22 +52,22 @@ The current categories for each label are as follows:
 
 ### Release Notes
 
-When making any end user facing changes in a contribution we have to make sure
+When making any end user-facing changes in a contribution, we have to make sure
 we document that when we release a new version of qiskit-aer. The expectation
-is that if your code contribution has user facing changes that you will write
+is that if your code contribution has user-facing changes that you will write
 the release documentation for these changes. This documentation must explain
 what was changed, why it was changed, and how users can either use or adapt
-to the change. The idea behind release documentation is that when a naive
+to the change. The idea behind the release documentation is that when a naive
 user with limited internal knowledge of the project is upgrading from the
 previous release to the new one, they should be able to read the release notes,
-understand if they need to update their program which uses qiskit, and how they
+understand if they need to update their program which uses Qiskit, and how they
 would go about doing that. It ideally should explain why they need to make
 this change too, to provide the necessary context.
 
-To make sure we don't forget a release note or if the details of user facing
-changes over a release cycle we require that all user facing changes include
-documentation at the same time as the code. To accomplish this we use the
-[reno](https://docs.openstack.org/reno/latest/) tool which enables a git based
+To make sure we don't forget a release note or if the details of user-facing
+changes over a release cycle, we require that all user facing changes include
+documentation at the same time as the code. To accomplish this, we use the
+[reno](https://docs.openstack.org/reno/latest/) tool which enables a git-based
 workflow for writing and compiling release notes.
 
 #### Adding a new release note
@@ -77,21 +77,21 @@ installed with::
 
     pip install -U reno
 
-Once you have reno installed you can make a new release note by running in
+Once you have reno installed, you can make a new release note by running in
 your local repository checkout's root::
 
     reno new short-description-string
 
 where short-description-string is a brief string (with no spaces) that describes
 what's in the release note. This will become the prefix for the release note
-file. Once that is run it will create a new yaml file in releasenotes/notes.
+file. Once that is run, it will create a new yaml file in releasenotes/notes.
 Then open that yaml file in a text editor and write the release note. The basic
 structure of a release note is restructured text in yaml lists under category
 keys. You add individual items under each category and they will be grouped
 automatically by release when the release notes are compiled. A single file
 can have as many entries in it as needed, but to avoid potential conflicts
-you'll want to create a new file for each pull request that has user facing
-changes. When you open the newly created file it will be a full template of
+you'll want to create a new file for each pull request that has user-facing
+changes. When you open the newly created file, it will be a full template of
 the different categories with a description of a category as a single entry
 in each category. You'll want to delete all the sections you aren't using and
 update the contents for those you are. For example, the end result should
@@ -132,19 +132,19 @@ deprecations:
 You can also look at other release notes for other examples.
 
 You can use any restructured text feature in them (code sections, tables,
-enumerated lists, bulleted list, etc) to express what is being changed as
-needed. In general you want the release notes to include as much detail as
+enumerated lists, bulleted list, etc.) to express what is being changed as
+needed. In general, you want the release notes to include as much detail as
 needed so that users will understand what has changed, why it changed, and how
 they'll have to update their code.
 
-After you've finished writing your release notes you'll want to add the note
+After you've finished writing your release notes, you'll want to add the note
 file to your commit with `git add` and commit them to your PR branch to make
 sure they're included with the code in your PR.
 
 ##### Linking to issues
 
-If you need to link to an issue or other github artifact as part of the release
-note this should be done using an inline link with the text being the issue
+If you need to link to an issue or other GitHub artifact as part of the release
+note, this should be done using an inline link with the text being the issue
 number. For example you would write a release note with a link to issue 12345
 as:
 
@@ -158,12 +158,12 @@ fixes:
 
 #### Generating the release notes
 
-After release notes have been added if you want to see what the full output of
-the release notes. In general the output from reno that we'll get is a rst
+After release notes have been added, if you want to see the full output of
+the release notes, you'll get the output as an rst
 (ReStructuredText) file that can be compiled by
-[sphinx](https://www.sphinx-doc.org/en/master/). To generate the rst file you
-use the ``reno report`` command. If you want to generate the full aer release
-notes for all releases (since we started using reno during 0.9) you just run::
+[sphinx](https://www.sphinx-doc.org/en/master/). To generate the rst file, you
+use the ``reno report`` command. If you want to generate the full Aer release
+notes for all releases (since we started using reno during 0.9), you just run::
 
     reno report
 
@@ -172,7 +172,7 @@ it has been tagged::
 
     reno report --version 0.5.0
 
-At release time ``reno report`` is used to generate the release notes for the
+At release time, ``reno report`` is used to generate the release notes for the
 release and the output will be submitted as a pull request to the documentation
 repository's [release notes file](
 https://github.com/Qiskit/qiskit/blob/master/docs/release_notes.rst)
@@ -180,18 +180,18 @@ https://github.com/Qiskit/qiskit/blob/master/docs/release_notes.rst)
 #### Building release notes locally
 
 Building The release notes are part of the standard qiskit-aer documentation
-builds. To check what the rendered html output of the release notes will look
-like for the current state of the repo you can run: `tox -edocs` which will
+builds. To check what the rendered HTML output of the release notes will look
+like for the current state of the repo, you can run: `tox -edocs` which will
 build all the documentation into `docs/_build/html` and the release notes in
 particular will be located at `docs/_build/html/release_notes.html`
 
 ### Development Cycle
 
 The development cycle for qiskit-aer is all handled in the open using
-the project boards in Github for project management. We use milestones
-in Github to track work for specific releases. The features or other changes
-that we want to include in a release will be tagged and discussed in Github.
-As we're preparing a new release we'll document what has changed since the
+the project boards in GitHub for project management. We use milestones
+in GitHub to track work for specific releases. The features or other changes
+that we want to include in a release will be tagged and discussed in GitHub.
+As we're preparing a new release, we'll document what has changed since the
 previous version in the release notes.
 
 ### Branches
@@ -211,7 +211,7 @@ merged to it are bugfixes.
 
 ### Release cycle
 
-When it is time to release a new minor version of qiskit-aer we will:
+When it is time to release a new minor version of qiskit-aer, we will:
 
 1.  Create a new tag with the version number and push it to github
 2.  Change the `master` version to the next release version.
@@ -222,7 +222,7 @@ the following steps:
 1.  Create a stable branch for the new minor version from the release tag
     on the `master` branch
 2.  Build and upload binary wheels to pypi
-3.  Create a github release page with a generated changelog
+3.  Create a GitHub release page with a generated changelog
 4.  Generate a PR on the meta-repository to bump the Aer version and
     meta-package version.
 
@@ -275,7 +275,7 @@ You're now ready to build from source! Follow the instructions for your platform
 
 ### Linux
 
-Qiskit is officially supported on Red Hat, CentOS, Fedora and Ubuntu distributions, as long as you can install a GCC version that is C++14 compatible and the few dependencies we need.
+Qiskit is officially supported on Red Hat, CentOS, Fedora, and Ubuntu distributions, as long as you can install a GCC version that is C++14 compatible and a few dependencies we need.
 
 #### <a name="linux-dependencies"> Dependencies </a>
 
@@ -310,7 +310,7 @@ Ubuntu
     $ sudo apt install libopenblas-dev
 
 
-And of course, `git` is required in order to build from repositories
+And of course, `git` is required to build from repositories
 
 CentOS/Red Hat
 
@@ -328,17 +328,17 @@ Ubuntu
 
 There are two ways of building `Aer` simulators, depending on your goal:
 
-1. Build a python extension that works with Terra.
+1. Build a Python extension that works with Terra.
 2. Build a standalone executable.
 
 **Python extension**
 
-As any other python package, we can install from source code by just running:
+As any other Python package, we can install from source code by just running:
 
     qiskit-aer$ pip install .
 
 This will build and install `Aer` with the default options which is probably suitable for most of the users.
-There's another pythonic approach to build and install software: build the wheels distributable file.
+There's another Pythonic approach to build and install software: build the wheels distributable file.
 
     qiskit-aer$ python ./setup.py bdist_wheel
 
@@ -374,9 +374,9 @@ the `dist/` directory, so next step is installing it:
 
 **Standalone Executable**
 
-If we want to build a standalone executable, we have to use *CMake* directly.
+If you want to build a standalone executable, you have to use *CMake* directly.
 The preferred way *CMake* is meant to be used, is by setting up an "out of
-source" build. So in order to build our standalone executable, we have to follow
+source" build. So in order to build your standalone executable, you have to follow
 these steps:
 
     qiskit-aer$ mkdir out
@@ -396,8 +396,8 @@ option):
 **Advanced options**
 
 Because the standalone version of `Aer` doesn't need Python at all, the build system is
-based on CMake, just like most of other C++ projects. So in order to pass all the different
-options we have on `Aer` to CMake we use it's native mechanism:
+based on CMake, just like most of other C++ projects. So to pass all the different
+options we have on `Aer` to CMake, we use its native mechanism:
 
     qiskit-aer/out$ cmake -DCMAKE_CXX_COMPILER=g++-9 -DAER_BLAS_LIB_PATH=/path/to/my/blas ..
 
@@ -421,17 +421,17 @@ You further need to have *Xcode Command Line Tools* installed on macOS:
 
 There are two ways of building `Aer` simulators, depending on your goal:
 
-1. Build a python extension that works with Terra;
+1. Build a Python extension that works with Terra;
 2. Build a standalone executable.
 
 **Python extension**
 
-As any other python package, we can install from source code by just running:
+As any other Python package, we can install from source code by just running:
 
     qiskit-aer$ pip install .
 
 This will build and install `Aer` with the default options which is probably suitable for most of the users.
-There's another pythonic approach to build and install software: build the wheels distributable file.
+There's another Pythonic approach to build and install software: build the wheels distributable file.
 
 
    qiskit-aer$ python ./setup.py bdist_wheel
@@ -467,9 +467,9 @@ the `dist/` directory, so next step is installing it:
 
 **Standalone Executable**
 
-If we want to build a standalone executable, we have to use **CMake** directly.
+If you want to build a standalone executable, you have to use **CMake** directly.
 The preferred way **CMake** is meant to be used, is by setting up an "out of
-source" build. So in order to build our standalone executable, we have to follow
+source" build. So in order to build your standalone executable, you have to follow
 these steps:
 
     qiskit-aer$ mkdir out
@@ -488,8 +488,8 @@ option):
 ***Advanced options***
 
 Because the standalone version of `Aer` doesn't need Python at all, the build system is
-based on CMake, just like most of other C++ projects. So in order to pass all the different
-options we have on `Aer` to CMake we use it's native mechanism:
+based on CMake, just like most of other C++ projects. So to pass all the different
+options we have on `Aer` to CMake, we use its native mechanism:
 
     qiskit-aer/out$ cmake -DCMAKE_CXX_COMPILER=g++-9 -DAER_BLAS_LIB_PATH=/path/to/my/blas ..
 
@@ -499,7 +499,7 @@ options we have on `Aer` to CMake we use it's native mechanism:
 
 #### <a name="win-dependencies"> Dependencies </a>
 
-On Windows, you must have *Anaconda3* installed. We recommend also installing
+On Windows, you must have *Anaconda3* installed. We also recommend installing
 *Visual Studio 2017 Community Edition* or *Visual Studio 2019 Community Edition*.
 
 >*Anaconda 3* can be installed from their web:
@@ -518,19 +518,19 @@ create an Anaconda virtual environment or activate it if you already have create
 We only support *Visual Studio* compilers on Windows, so if you have others installed in your machine (MinGW, TurboC)
 you have to make sure that the path to the *Visual Studio* tools has precedence over others so that the build system
 can get the correct one.
-There's a (recommended) way to force the build system to use the one you want by using CMake `-G` parameter. Will talk
+There's a (recommended) way to force the build system to use the one you want by using CMake `-G` parameter. We will talk
 about this and other parameters later.
 
 #### <a name="win-build"> Build </a>
 
 **Python extension**
 
-As any other python package, we can install from source code by just running:
+As any other Python package, we can install from source code by just running:
 
     (QiskitDevEnv) qiskit-aer > pip install .
 
 This will build and install `Aer` with the default options which is probably suitable for most of the users.
-There's another pythonic approach to build and install software: build the wheels distributable file.
+There's another Pythonic approach to build and install software: build the wheels distributable file.
 
 
    (QiskitDevEnv) qiskit-aer > python ./setup.py bdist_wheel
@@ -566,9 +566,9 @@ the `dist/` directory, so next step is installing it:
 
 **Standalone Executable**
 
-If we want to build a standalone executable, we have to use **CMake** directly.
+If you want to build a standalone executable, you have to use **CMake** directly.
 The preferred way **CMake** is meant to be used, is by setting up an "out of
-source" build. So in order to build our standalone executable, we have to follow
+source" build. So in order to build our standalone executable, you have to follow
 these steps:
 
     (QiskitDevEnv) qiskit-aer> mkdir out
@@ -587,8 +587,8 @@ option):
 ***Advanced options***
 
 Because the standalone version of `Aer` doesn't need Python at all, the build system is
-based on CMake, just like most of other C++ projects. So in order to pass all the different
-options we have on `Aer` to CMake we use it's native mechanism:
+based on CMake, just like most of other C++ projects. So to pass all the different
+options we have on `Aer` to CMake, we use its native mechanism:
 
     (QiskitDevEnv) qiskit-aer\out> cmake -G "Visual Studio 15 2017" -DAER_BLAS_LIB_PATH=c:\path\to\my\blas ..
 
@@ -596,11 +596,11 @@ options we have on `Aer` to CMake we use it's native mechanism:
 ### Building with GPU support
 
 Qiskit Aer can exploit GPU's horsepower to accelerate some simulations, specially the larger ones.
-GPU access is supported via CUDA® (NVIDIA® chipset), so in order to build with GPU support we need
+GPU access is supported via CUDA® (NVIDIA® chipset), so to build with GPU support, you need
 to have CUDA® >= 10.1 preinstalled. See install instructions [here](https://developer.nvidia.com/cuda-toolkit-archive)
 Please note that we only support GPU acceleration on Linux platforms at the moment.
 
-Once CUDA® is properly installed, we only need to set a flag so the build system knows what to do:
+Once CUDA® is properly installed, you only need to set a flag so the build system knows what to do:
 
 ```
 AER_THRUST_BACKEND=CUDA
@@ -610,8 +610,8 @@ For example,
 
     qiskit-aer$ python ./setup.py bdist_wheel -- -DAER_THRUST_BACKEND=CUDA
 
-If we want to specify the CUDA® architecture instead of letting the build system
-auto detect it, we can use the AER_CUDA_ARCH flag (can also be set as an ENV variable
+If you want to specify the CUDA® architecture instead of letting the build system 
+auto detect it, you can use the AER_CUDA_ARCH flag (can also be set as an ENV variable
 with the same name, although the flag takes precedence). For example:
 
     qiskit-aer$ python ./setup.py bdist_wheel -- -DAER_THRUST_BACKEND=CUDA -DAER_CUDA_ARCH="5.2"
@@ -800,7 +800,7 @@ pass them right after ``-D`` CMake argument. Example:
 qiskit-aer/out$ cmake -DUSEFUL_FLAG=Value ..
 ```
 
-In the case of building the Qiskit python extension, you have to pass these flags after writing
+In the case of building the Qiskit Python extension, you have to pass these flags after writing
 ``--`` at the end of the python command line, eg:
 
 ```
@@ -820,8 +820,7 @@ These are the flags:
 * AER_BLAS_LIB_PATH
 
     Tells CMake the directory to look for the BLAS library instead of the usual paths.
-    If no BLAS library is found under that directory, CMake will raise an error and stop.
-
+    If no BLAS library is found under that directory, CMake will raise an error and terminate.
     It can also be set as an ENV variable with the same name, although the flag takes precedence.
 
     Values: An absolute path.
@@ -847,8 +846,8 @@ These are the flags:
 
 * AER_THRUST_BACKEND
 
-    We use Thrust library for GPU support through CUDA. If we want to build a version of `Aer` with GPU acceleration, we need to install CUDA and set this variable to the value: "CUDA".
-    There are other values that will use different CPU methods depending on the kind of backend we want to use:
+    We use Thrust library for GPU support through CUDA. If you want to build a version of `Aer` with GPU acceleration, you need to install CUDA and set this variable to the value: "CUDA".
+    There are other values that will use different CPU methods depending on the kind of backend you want to use:
     - "OMP": For OpenMP support
     - "TBB": For Intel Threading Building Blocks
 
@@ -858,7 +857,7 @@ These are the flags:
 
 * AER_CUDA_ARCH
 
-    This flag allows us we to specify the CUDA architecture instead of letting the build system auto detect it.
+    This flag allows you to specify the CUDA architecture instead of letting the build system auto detect it.
     It can also be set as an ENV variable with the same name, although the flag takes precedence.
 
     Values:  Auto | Common | All | List of valid CUDA architecture(s).
@@ -908,13 +907,13 @@ These are the flags:
 
 ## Tests
 
-Code contribution are expected to include tests that provide coverage for the
+Code contributions are expected to include tests that provide coverage for the
 changes being made.
 
 We have two types of tests in the codebase: Qiskit Terra integration tests and
 Standalone integration tests.
 
-For Qiskit Terra integration tests, you first need to build and install the Qiskit python extension, and then run `unittest` Python framework.
+For Qiskit Terra integration tests, you first need to build and install the Qiskit Python extension, and then run `unittest` Python framework.
 
 ```
 qiskit-aer$ pip install .
@@ -923,7 +922,7 @@ qiskit-aer$ stestr run
 
 Manual for `stestr` can be found [here](https://stestr.readthedocs.io/en/latest/MANUAL.html#).
 
-The integration tests for Qiskit python extension are included in: `test/terra`.
+The integration tests for Qiskit Python extension are included in: `test/terra`.
 
 ## C++ Tests
 
@@ -952,17 +951,17 @@ corresponding tests to verify this compatibility.
 
 ## Debug
 
-We have to build in debug mode if we want to start a debugging session with tools like `gdb` or `lldb`.
-In order to create a Debug build for all platforms, we just need to pass a parameter while invoking the build to
+You have to build in debug mode if you want to start a debugging session with tools like `gdb` or `lldb`.
+To create a Debug build for all platforms, you just need to pass a parameter while invoking the build to
 create the wheel file:
 
     qiskit-aer$> python ./setup.py bdist_wheel --build-type=Debug
 
-If you want to debug the standalone executable, then the parameter changes to:
+If you want to debug the standalone executable, the parameter changes to:
 
     qiskit-aer/out$> cmake -DCMAKE_BUILD_TYPE=Debug
 
-There are three different build configurations: `Release`, `Debug`, and `Release with Debug Symbols`, which parameters are:
+There are three different build configurations: `Release`, `Debug`, and `Release with Debug Symbols`, whose parameters are:
 `Release`, `Debug`, `RelWithDebInfo` respectively.
 
 We recommend building in verbose mode and dump all the output to a file so it's easier to inspect possible build issues:
@@ -976,7 +975,7 @@ On Windows:
     qisikt-aer> set VERBOSE=1
     qiskit-aer> python ./setup.py bdist_wheel --build-type=Debug 1> build.log 2>&1
 
-We encourage to always send the whole `build.log` file when reporting a build issue, otherwise we will ask for it :)
+We encourage you to always send the whole `build.log` file when reporting a build issue, otherwise we will ask for it :)
 
 
 **Stepping through the code**
@@ -986,9 +985,9 @@ Standalone version doesn't require anything special, just use your debugger like
     qiskit-aer/out/Debug$ gdb qasm_simulator
 
 Stepping through the code of a Python extension is another story, trickier, but possible. This is because Python interpreters
-usually load Python extensions dynamically, so we need to start debugging the python interpreter and set our breakpoints ahead of time, before any of our python extension symbols are loaded into the process.
+usually load Python extensions dynamically, so we need to start debugging the Python interpreter and set our breakpoints ahead of time, before any of our Python extension symbols are loaded into the process.
 
-Once built and installed we have to run the debugger with the python interpreter:
+Once built and installed, we have to run the debugger with the Python interpreter:
 
     $ lldb python
 
@@ -1004,9 +1003,9 @@ Then we have to set our breakpoints:
     Breakpoint 1: no locations (pending).
     WARNING:  Unable to resolve breakpoint to any actual locations.
 
-Here the message is clear, it can't find the function: `AER::controller_execute` because our python extension hasn't been loaded yet
- by the python interpreter, so it's "on-hold" hoping to find the function later in the execution.
-Now we can run the python interpreter and pass the arguments (the python file to execute):
+Here the message is clear, it can't find the function: `AER::controller_execute` because our Python extension hasn't been loaded yet
+ by the Python interpreter, so it's "on-hold" hoping to find the function later in the execution.
+Now we can run the Python interpreter and pass the arguments (the python file to execute):
 
     (lldb) r test_qiskit_program.py
     Process 24896 launched: '/opt/anaconda3/envs/aer37/bin/python' (x86_64)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To install from source, follow the instructions in the [contribution guidelines]
 
 ## Installing GPU support
 
-In order to install and run the GPU supported simulators, you need CUDA&reg; 10.1 or newer previously installed.
+In order to install and run the GPU supported simulators on Linux, you need CUDA&reg; 10.1 or newer previously installed.
 CUDA&reg; itself would require a set of specific GPU drivers. Please follow CUDA&reg; installation procedure in the NVIDIA&reg; [web](https://www.nvidia.com/drivers).
 
 If you want to install our GPU supported simulators, you have to install this other package:
@@ -32,6 +32,11 @@ pip install qiskit-aer-gpu
 This will overwrite your current `qiskit-aer` package installation giving you
 the same functionality found in the canonical `qiskit-aer` package, plus the
 ability to run the GPU supported simulators: statevector, density matrix, and unitary.
+
+**Note**: This package is only available on x86_64 Linux. For other platforms
+that have CUDA support you will have to build from source. You can refer to
+the [contributing guide](https://github.com/Qiskit/qiskit-aer/blob/master/CONTRIBUTING.md#building-with-gpu-support)
+for instructions on doing this.
 
 ## Simulating your first quantum program with Qiskit Aer
 Now that you have Qiskit Aer installed, you can start simulating quantum circuits with noise. Here is a basic example:

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -524,8 +524,8 @@ class QasmSimulator(AerBackend):
             config.custom_instructions = sorted(['roerror', 'snapshot', 'save_statevector',
                                                  'save_expval', 'save_expval_var'])
             config.basis_gates = sorted([
-                'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'sx', 'swap',
-                'u0', 'u1', 'p', 'ccx', 'ccz', 'delay'
+                'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'sx',
+                'swap', 'u0', 't', 'tdg', 'u1', 'p', 'ccx', 'ccz', 'delay'
             ] + config.custom_instructions)
 
         return config

--- a/qiskit/providers/aer/extensions/__init__.py
+++ b/qiskit/providers/aer/extensions/__init__.py
@@ -20,6 +20,12 @@ Circuit Extensions (:mod:`qiskit.providers.aer.extensions`)
 Snapshots
 =========
 
+.. note:
+
+    Snapshot extensions will be deprecated after qiskit-aer 0.8 release.
+    They have been superceded by the save instructions in the
+    :mod:`qiskit.providers.aer.library` module.
+
 Snapshot instructions allow taking a snapshot of the current state of the
 simulator without effecting the outcome of the simulation. These can be
 used with the `QasmSimulator` backend to return the expectation value of

--- a/qiskit/providers/aer/extensions/snapshot_density_matrix.py
+++ b/qiskit/providers/aer/extensions/snapshot_density_matrix.py
@@ -14,6 +14,7 @@
 Simulator command to snapshot internal simulator representation.
 """
 
+from warnings import warn
 from qiskit import QuantumCircuit
 from .snapshot import Snapshot
 
@@ -30,7 +31,16 @@ class SnapshotDensityMatrix(Snapshot):
 
         Raises:
             ExtensionError: if snapshot is invalid.
+
+        .. note::
+
+            This instruction will be deprecated after the qiskit-aer 0.8 release.
+            It has been superseded by the
+            :class:`qiskit.providers.aer.library.SaveDensityMatrix` instruction.
         """
+        warn('`The `SnapshotDensityMatrix` instruction will be deprecated in the'
+             'future. It has been superseded by the `SaveDensityMatrix`'
+             ' instructions.', PendingDeprecationWarning)
         super().__init__(label,
                          snapshot_type='density_matrix',
                          num_qubits=num_qubits)
@@ -49,8 +59,17 @@ def snapshot_density_matrix(self, label, qubits=None):
 
     Raises:
         ExtensionError: if snapshot is invalid.
-    """
 
+    .. note::
+
+        This method will be deprecated after the qiskit-aer 0.8 release.
+        It has been superseded by the
+        :func:`qiskit.providers.aer.library.save_density_matrix`
+        circuit method.
+    """
+    warn('`The `save_density_matrix` circuit method will be deprecated in the'
+         ' future. It has been superseded by the `save_density_matrix`'
+         ' circuit method.', PendingDeprecationWarning)
     snapshot_register = Snapshot.define_snapshot_register(self, qubits=qubits)
 
     return self.append(

--- a/qiskit/providers/aer/extensions/snapshot_expectation_value.py
+++ b/qiskit/providers/aer/extensions/snapshot_expectation_value.py
@@ -38,7 +38,19 @@ class SnapshotExpectationValue(Snapshot):
 
         Raises:
             ExtensionError: if snapshot is invalid.
+
+        .. note::
+
+            This instruction will be deprecated after the qiskit-aer 0.8 release.
+            It has been superseded by the
+            :class:`qiskit.providers.aer.library.SaveExpectationValue` and
+            :class:`qiskit.providers.aer.library.SaveExpectationValueVariance`
+            instructions.
         """
+        warn('The `SnapshotExpectationValue` instruction will be deprecated in the'
+             ' future. It has been superseded by the `SaveExpectationValue` and'
+             ' `SaveExpectationValueVariance` instructions.',
+             PendingDeprecationWarning)
         if variance:
             warn('The snapshot `variance` kwarg has been deprecated and will'
                  ' be removed in qiskit-aer 0.8. To compute variance use'
@@ -140,8 +152,19 @@ def snapshot_expectation_value(self, label, op, qubits,
 
     Raises:
         ExtensionError: if snapshot is invalid.
-    """
 
+    .. note::
+
+        This method will be deprecated after the qiskit-aer 0.8 release.
+        It has been superseded by the
+        :func:`qiskit.providers.aer.library.save_expectation_value` and
+        :func:`qiskit.providers.aer.library.save_expectation_value_variance`
+        circuit methods.
+    """
+    warn('The `snapshot_expectation_value` circuit method will be deprecated '
+         ' in the future. It has been superseded by the `save_expectation_value`'
+         ' and `save_expectation_value_variance` circuit methods.',
+         PendingDeprecationWarning)
     snapshot_register = Snapshot.define_snapshot_register(self, qubits=qubits)
 
     return self.append(

--- a/qiskit/providers/aer/extensions/snapshot_probabilities.py
+++ b/qiskit/providers/aer/extensions/snapshot_probabilities.py
@@ -32,7 +32,19 @@ class SnapshotProbabilities(Snapshot):
 
         Raises:
             ExtensionError: if snapshot is invalid.
+
+        .. note::
+
+            This instruction will be deprecated after the qiskit-aer 0.8 release.
+            It has been superseded by the
+            :class:`qiskit.providers.aer.library.SaveProbabilities` and
+            :class:`qiskit.providers.aer.library.SaveProbabilitiesDict`
+            instructions.
         """
+        warn('The `SnapshotProbabilities` instruction will be deprecated in the'
+             ' future. It has been superseded by the `SaveProbabilities` and'
+             ' `SaveProbabilitiesDict` instructions.',
+             PendingDeprecationWarning)
         if variance:
             warn('The snapshot `variance` kwarg has been deprecated and will be removed'
                  ' in qiskit-aer 0.8.', DeprecationWarning)
@@ -54,7 +66,19 @@ def snapshot_probabilities(self, label, qubits, variance=False):
 
     Raises:
         ExtensionError: if snapshot is invalid.
+
+    .. note::
+
+        This method will be deprecated after the qiskit-aer 0.8 release.
+        It has been superseded by the
+        :func:`qiskit.providers.aer.library.save_probabilities` and
+        :func:`qiskit.providers.aer.library.save_probabilities_dict`
+        circuit methods.
     """
+    warn('The `snapshot_probabilities` circuit method will be deprecated '
+         ' in the future. It has been superseded by the `save_probabilities`'
+         ' and `save_probabilities_dict` circuit methods.',
+         PendingDeprecationWarning)
     snapshot_register = Snapshot.define_snapshot_register(self, qubits=qubits)
 
     return self.append(

--- a/qiskit/providers/aer/extensions/snapshot_stabilizer.py
+++ b/qiskit/providers/aer/extensions/snapshot_stabilizer.py
@@ -14,6 +14,7 @@
 Simulator command to snapshot internal simulator representation.
 """
 
+from warnings import warn
 from qiskit import QuantumCircuit
 from .snapshot import Snapshot
 
@@ -36,7 +37,16 @@ class SnapshotStabilizer(Snapshot):
             The number of qubits parameter specifies the size of the
             instruction as a barrier and should be set to the number of
             qubits in the circuit.
+
+        .. note::
+
+            This instruction will be deprecated after the qiskit-aer 0.8 release.
+            It has been superseded by the
+            :class:`qiskit.providers.aer.library.SaveStabilizer` instruction.
         """
+        warn('The `SnapshotStabilizer` instruction will be deprecated in the'
+             ' future. It has been superseded by the `save_stabilizer`'
+             ' instructions.', PendingDeprecationWarning)
         super().__init__(label, snapshot_type='stabilizer', num_qubits=num_qubits)
 
 
@@ -57,8 +67,17 @@ def snapshot_stabilizer(self, label):
         The number of qubits parameter specifies the size of the
         instruction as a barrier and should be set to the number of
         qubits in the circuit.
-    """
 
+    .. note::
+
+        This method will be deprecated after the qiskit-aer 0.8 release.
+        It has been superseded by the
+        :func:`qiskit.providers.aer.library.save_stabilizer` circuit
+        method.
+    """
+    warn('`The `save_stabilizer` circuit method will be deprecated in the'
+         ' future. It has been superseded by the `save_stabilizer`'
+         ' circuit method.', PendingDeprecationWarning)
     snapshot_register = Snapshot.define_snapshot_register(self)
 
     return self.append(

--- a/qiskit/providers/aer/extensions/snapshot_statevector.py
+++ b/qiskit/providers/aer/extensions/snapshot_statevector.py
@@ -13,7 +13,7 @@
 """
 Simulator command to snapshot internal simulator representation.
 """
-
+from warnings import warn
 from qiskit import QuantumCircuit
 from .snapshot import Snapshot
 
@@ -36,7 +36,16 @@ class SnapshotStatevector(Snapshot):
             The number of qubits parameter specifies the size of the
             instruction as a barrier and should be set to the number of
             qubits in the circuit.
+
+        .. note::
+
+            This instruction will be deprecated after the qiskit-aer 0.8 release.
+            It has been superseded by the
+            :class:`qiskit.providers.aer.library.SaveStatevector` instruction.
         """
+        warn('`The `SnapshotStatevector` instruction will be deprecated in the'
+             'future. It has been superseded by the `SaveStatevector`'
+             ' instructions.', PendingDeprecationWarning)
         super().__init__(label, snapshot_type='statevector', num_qubits=num_qubits)
 
 
@@ -57,7 +66,17 @@ def snapshot_statevector(self, label):
         The number of qubits parameter specifies the size of the
         instruction as a barrier and should be set to the number of
         qubits in the circuit.
+
+    .. note::
+
+        This method will be deprecated after the qiskit-aer 0.8 release.
+        It has been superseded by the
+        :func:`qiskit.providers.aer.library.save_statevector` circuit
+        method.
     """
+    warn('`The `save_statevector` circuit method will be deprecated in the'
+         ' future. It has been superseded by the `save_statevector`'
+         ' circuit method.', PendingDeprecationWarning)
     # Statevector snapshot acts as a barrier across all qubits in the
     # circuit
     snapshot_register = Snapshot.define_snapshot_register(self)

--- a/qiskit/providers/aer/noise/device/models.py
+++ b/qiskit/providers/aer/noise/device/models.py
@@ -249,11 +249,11 @@ def _excited_population(freq, temperature):
     if freq != inf and temperature != 0:
         # Compute the excited state population from qubit
         # frequency and temperature
-        # Boltzman constant  kB = 6.62607015e-34 (eV/K)
-        # Planck constant h =  6.62607015e-34 (eV.s)
+        # Boltzman constant  kB = 8.617333262-5 (eV/K)
+        # Planck constant h = 4.135667696e-15 (eV.s)
         # qubit temperature temperatue = T (mK)
         # qubit frequency frequency = f (GHz)
-        # excited state population = 1/(1+exp((2hf*1e9)/(kbT*1e-3)))
+        # excited state population = 1/(1+exp((2*h*f*1e9)/(kb*T*1e-3)))
         exp_param = exp((95.9849 * freq) / abs(temperature))
         population = 1 / (1 + exp_param)
         if temperature < 0:

--- a/qiskit/providers/aer/noise/errors/readout_error.py
+++ b/qiskit/providers/aer/noise/errors/readout_error.py
@@ -44,9 +44,9 @@ class ReadoutError:
 
             probabilities[m] = [P(0|m), P(1|m), ..., P(2 ** N - 1|m)]
 
-        where ``P(j|m)`` is the probability of recording a measurement outcome
-        of ``m`` as the value ``j``. Where ``j`` and ``m`` are integer
-        representations of bit-strings.
+        where ``P(n|m)`` is the probability of recording a noisy measurement
+        outcome as ``n`` given the true ideal measurement outcome was ``m``,
+        where ``n`` and ``m`` are integer representations of bit-strings.
 
         **Example: 1-qubit**
 

--- a/qiskit/providers/aer/utils/noise_transformation.py
+++ b/qiskit/providers/aer/utils/noise_transformation.py
@@ -214,10 +214,7 @@ def approximate_noise_model(model, *,
         error_dict["gate_qubits"] = [model._str2qubits(qubits_str)]
         error_list.append(error_dict)
 
-    approx_noise_model = NoiseModel.from_dict({
-        "errors": error_list,
-        "x90_gates": model._x90_gates
-    })
+    approx_noise_model = NoiseModel.from_dict({"errors": error_list})
     # Update basis gates
     approx_noise_model._basis_gates = model._basis_gates
     return approx_noise_model

--- a/releasenotes/notes/issue1126-e2d51f660b0078db.yaml
+++ b/releasenotes/notes/issue1126-e2d51f660b0078db.yaml
@@ -1,0 +1,7 @@
+---
+
+fixes:
+  - |
+    Fixed issue #1126: bug in reporting measurement of a single qubit. The bug 
+    occured when copying the measured value to the output data structure.
+

--- a/releasenotes/notes/remove-deprecated-ba6eb1060207af99.yaml
+++ b/releasenotes/notes/remove-deprecated-ba6eb1060207af99.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    Removed x90 gate decomposition from noise models that was deprecated
+    in qiskit-aer 0.7. This decomposition is now done by using regular
+    noise model basis gates and the qiskit transpiler.

--- a/src/framework/creg.hpp
+++ b/src/framework/creg.hpp
@@ -138,20 +138,6 @@ bool ClassicalRegister::check_conditional(const Operations::Op &op) const {
   // Check if op is conditional
   if (op.conditional)
     return (creg_register_[creg_register_.size() - op.conditional_reg - 1] == '1');
-  
-  // DEPRECATED: old style conditional
-  if (op.old_conditional) {
-    std::string current;
-    auto mask = Utils::padleft(Utils::hex2bin(op.old_conditional_mask, false),
-                               '0', creg_memory_.size());
-    for (size_t pos=0; pos < mask.size(); pos++) {
-      if (mask[pos] == '1')
-        current.push_back(creg_memory_[pos]);
-    }
-    auto val = Utils::padleft(Utils::hex2bin(op.old_conditional_val, false),
-                              '0', current.size());
-    return (val == current);
-  }
 
   // Op is not conditional
   return true;

--- a/src/framework/linalg/vector.hpp
+++ b/src/framework/linalg/vector.hpp
@@ -203,6 +203,7 @@ template <class T>
 Vector<T>::Vector(Vector<T> &&other) noexcept
     : size_(other.size_), data_(other.data_) {
   other.data_ = nullptr;
+  other.size_ = 0;
 }
 
 //-----------------------------------------------------------------------
@@ -214,6 +215,7 @@ template <class T> Vector<T> &Vector<T>::operator=(Vector<T> &&other) noexcept {
   size_ = other.size_;
   data_ = other.data_;
   other.data_ = nullptr;
+  other.size_ = 0;
   return *this;
 }
 

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -166,11 +166,6 @@ struct Op {
   uint_t conditional_reg;   // (opt) the (single) register location to look up for conditional
   RegComparison bfunc;      // (opt) boolean function relation
 
-  // DEPRECATED: Old style conditionals (remove in 0.3)
-  bool old_conditional = false;     // is gate old style conditional gate
-  std::string old_conditional_mask; // hex string for conditional mask
-  std::string old_conditional_val;  // hex string for conditional value
-
   // Measurement
   reg_t memory;             // (opt) register operation it acts on (measure)
   reg_t registers;          // (opt) register locations it acts on (measure, conditional)
@@ -586,16 +581,8 @@ void add_conditional(const Allowed allowed, Op& op, const json_t &js) {
       throw std::invalid_argument("Invalid instruction: \"" + op.name + "\" cannot be conditional.");
     }
     // If instruction is allowed to be conditional add parameters
-    if (js["conditional"].is_number()) {
-      // New style conditional
-      op.conditional_reg = js["conditional"];
-      op.conditional = true;
-    } else {
-      // DEPRECATED: old style conditional (remove in 0.3)
-      JSON::get_value(op.old_conditional_mask, "mask", js["conditional"]);
-      JSON::get_value(op.old_conditional_val, "val", js["conditional"]);
-      op.old_conditional = true;
-    }
+    op.conditional_reg = js["conditional"];
+    op.conditional = true;
   }
 }
 
@@ -788,7 +775,6 @@ Op json_to_op_roerror(const json_t &js) {
   op.name = "roerror";
   JSON::get_value(op.memory, "memory", js);
   JSON::get_value(op.registers, "register", js);
-  JSON::get_value(op.probs, "probabilities", js); // DEPRECATED: Remove in 0.4
   JSON::get_value(op.probs, "params", js);
   // Conditional
   add_conditional(Allowed::No, op, js);

--- a/src/framework/utils.hpp
+++ b/src/framework/utils.hpp
@@ -959,6 +959,31 @@ std::map<std::string, T> vec2ket(const T* const vec, uint_t dim, double epsilon,
   return ketmap;
 }
 
+template <typename T>
+std::map<std::string, T> vec2ket(const std::vector<T> &vec, const reg_t& index, uint_t dim, uint_t base) {
+
+  bool hex_output = false;
+  if (base == 16) {
+    hex_output = true;
+    base = 2; // If hexadecimal strings we convert to bin first
+  }
+  // check vector length
+  double n = std::log(dim) / std::log(base);
+  uint_t nint = std::trunc(n);
+  if (std::abs(nint - n) > 1e-5) {
+    std::stringstream ss;
+    ss << "vec2ket (vector dimension " << dim << " is not of size " << base << "^n)";
+    throw std::invalid_argument(ss.str());
+  }
+  std::map<std::string, T> ketmap;
+  for (size_t k = 0; k < vec.size(); ++k) {
+    std::string key = (hex_output) ? Utils::int2hex(index[k])
+                                   : Utils::int2string(index[k], base, nint);
+    ketmap.insert({key, vec[k]});
+  }
+  return ketmap;
+}
+
 //==============================================================================
 // Implementations: Bit conversions
 //==============================================================================

--- a/src/misc/warnings.hpp
+++ b/src/misc/warnings.hpp
@@ -30,9 +30,10 @@
   DISABLE_WARNING(-Wall)                                                       \
   DISABLE_WARNING(-Wextra)                                                     \
   DISABLE_WARNING(-Wshadow)                                                    \
-  DISABLE_WARNING(-Wfloat-equal)                                             \
+  DISABLE_WARNING(-Wfloat-equal)                                               \
   DISABLE_WARNING(-Wundef)                                                     \
   DISABLE_WARNING(-Wpedantic)                                                  \
+  DISABLE_WARNING(-Wredundant-decls)                                           \
   DISABLE_WARNING(-Wsign-compare)
 
 #define DISABLE_WARNING_POP DO_PRAGMA(GCC diagnostic pop)

--- a/src/misc/wrap_thrust.hpp
+++ b/src/misc/wrap_thrust.hpp
@@ -1,0 +1,49 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2020.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_misc_wrap_thrust_hpp_
+#define _aer_misc_wrap_thrust_hpp_
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC system_header
+#endif
+
+#include "misc/warnings.hpp"
+DISABLE_WARNING_PUSH
+#include <thrust/for_each.h>
+#include <thrust/complex.h>
+#include <thrust/inner_product.h>
+#include <thrust/transform.h>
+#include <thrust/transform_scan.h>
+#include <thrust/binary_search.h>
+#include <thrust/execution_policy.h>
+#include <thrust/functional.h>
+#include <thrust/tuple.h>
+#include <thrust/iterator/constant_iterator.h>
+#include <thrust/detail/vector_base.h>
+
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+#include <thrust/iterator/permutation_iterator.h>
+#include <thrust/fill.h>
+
+#ifdef AER_THRUST_CUDA
+#include <thrust/device_vector.h>
+#endif
+#include <thrust/host_vector.h>
+
+#include <thrust/system/omp/execution_policy.h>
+DISABLE_WARNING_POP
+
+#endif // inclusion guard

--- a/src/simulators/density_matrix/densitymatrix_state.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state.hpp
@@ -129,7 +129,7 @@ public:
   virtual std::vector<reg_t> sample_measure(const reg_t &qubits, uint_t shots,
                                             RngEngine &rng) override;
 
-  virtual void allocate(uint_t num_qubits);
+  virtual void allocate(uint_t num_qubits) override;
 
   //-----------------------------------------------------------------------
   // Additional methods

--- a/src/simulators/density_matrix/densitymatrix_state_chunk.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state_chunk.hpp
@@ -124,10 +124,10 @@ protected:
   virtual void apply_op(const int_t iChunk,const Operations::Op &op,
                          ExperimentResult &result,
                          RngEngine &rng,
-                         bool final_ops);
+                         bool final_ops) override;
 
   //swap between chunks
-  virtual void apply_chunk_swap(const reg_t &qubits);
+  virtual void apply_chunk_swap(const reg_t &qubits) override;
 
   // Applies a sypported Gate operation to the state class.
   // If the input is not in allowed_gates an exeption will be raised.
@@ -253,7 +253,7 @@ protected:
   // Threshold for chopping small values to zero in JSON
   double json_chop_threshold_ = 1e-10;
 
-  int qubit_scale(void)
+  int qubit_scale() override
   {
     return 2;
   }

--- a/src/simulators/density_matrix/densitymatrix_state_chunk.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state_chunk.hpp
@@ -614,8 +614,10 @@ double State<statevec_t>::expval_pauli(const reg_t &qubits,
     }
   }
 
+  int_t nrows = 1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)/2);
+
   if(qubits_out_chunk.size() > 0){  //there are bits out of chunk
-    std::complex<double> coeff = 1.0;
+    std::complex<double> phase = 1.0;
 
     std::reverse(pauli_out_chunk.begin(),pauli_out_chunk.end());
     std::reverse(pauli_in_chunk.begin(),pauli_in_chunk.end());
@@ -623,73 +625,49 @@ double State<statevec_t>::expval_pauli(const reg_t &qubits,
     uint_t x_mask, z_mask, num_y, x_max;
     std::tie(x_mask, z_mask, num_y, x_max) = AER::QV::pauli_masks_and_phase(qubits_out_chunk, pauli_out_chunk);
 
-    AER::QV::add_y_phase(num_y,coeff);
-
-    if(x_mask != 0){    //pairing state is out of chunk
-      bool on_same_process = true;
-#ifdef AER_MPI
-      int proc_bits = 0;
-      uint_t procs = distributed_procs_;
-      while(procs > 1){
-        if((procs & 1) != 0){
-          proc_bits = -1;
-          break;
-        }
-        proc_bits++;
-        procs >>= 1;
-      }
-      if(x_mask & (~((1ull << (BaseState::num_qubits_/2 - proc_bits)) - 1)) != 0){    //data exchange between processes is required
-        on_same_process = false;
-      }
-#endif
-
+    z_mask >>= (BaseState::chunk_bits_/2);
+    if(x_mask != 0){
       x_mask >>= (BaseState::chunk_bits_/2);
-      z_mask >>= (BaseState::chunk_bits_/2);
       x_max -= (BaseState::chunk_bits_/2);
+
+      AER::QV::add_y_phase(num_y,phase);
 
       const uint_t mask_u = ~((1ull << (x_max + 1)) - 1);
       const uint_t mask_l = (1ull << x_max) - 1;
 
-#pragma omp parallel for if(BaseState::chunk_omp_parallel_ && on_same_process) private(i) reduction(+:expval)
-      for(i=0;i<BaseState::num_global_chunks_/2;i++){
-        uint_t iChunk = ((i << 1) & mask_u) | (i & mask_l);
-        uint_t pair_chunk = iChunk ^ x_mask;
-        uint_t iProc = BaseState::get_process_by_chunk(pair_chunk);
+#pragma omp parallel for if(BaseState::chunk_omp_parallel_) private(i) reduction(+:expval)
+      for(i=0;i<nrows/2;i++){
+        uint_t irow = ((i << 1) & mask_u) | (i & mask_l);
+        uint_t iChunk = (irow ^ x_mask) + irow * nrows;
 
         if(BaseState::chunk_index_begin_[BaseState::distributed_rank_] <= iChunk && BaseState::chunk_index_end_[BaseState::distributed_rank_] > iChunk){  //on this process
-          uint_t z_count,z_count_pair;
-          z_count = AER::Utils::popcount(iChunk & z_mask);
-          z_count_pair = AER::Utils::popcount(pair_chunk & z_mask);
-
-          if(iProc == BaseState::distributed_rank_){  //pair is on the same process
-            expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[pair_chunk - BaseState::global_chunk_index_],z_count,z_count_pair,coeff);
-          }
-          else{
-            BaseState::recv_chunk(iChunk-BaseState::global_chunk_index_,pair_chunk);
-            //refer receive buffer to calculate expectation value
-            expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[iChunk-BaseState::global_chunk_index_],z_count,z_count_pair,coeff);
-          }
-        }
-        else if(iProc == BaseState::distributed_rank_){  //pair is on this process
-          BaseState::send_chunk(iChunk-BaseState::global_chunk_index_,pair_chunk);
+          double sign = 1.0;
+          if (z_mask && (AER::Utils::popcount(iChunk & z_mask) & 1))
+            sign = -1.0;
+          expval += sign * BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,phase);
         }
       }
     }
-    else{ //no exchange between chunks
-      z_mask >>= (BaseState::chunk_bits_/2);
+    else{
 #pragma omp parallel for if(BaseState::chunk_omp_parallel_) private(i) reduction(+:expval)
-      for(i=0;i<BaseState::num_local_chunks_;i++){
-        double sign = 1.0;
-        if (z_mask && (AER::Utils::popcount((i + BaseState::global_chunk_index_) & z_mask) & 1))
-          sign = -1.0;
-        expval += sign * BaseState::qregs_[i].expval_pauli(qubits_in_chunk, pauli_in_chunk,coeff);
+      for(i=0;i<nrows;i++){
+        uint_t iChunk = i * (nrows+1);
+        if(BaseState::chunk_index_begin_[BaseState::distributed_rank_] <= iChunk && BaseState::chunk_index_end_[BaseState::distributed_rank_] > iChunk){  //on this process
+          double sign = 1.0;
+          if (z_mask && (AER::Utils::popcount((i + BaseState::global_chunk_index_) & z_mask) & 1))
+            sign = -1.0;
+          expval += sign * BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk);
+        }
       }
     }
   }
   else{ //all bits are inside chunk
 #pragma omp parallel for if(BaseState::chunk_omp_parallel_) private(i) reduction(+:expval)
-    for(i=0;i<BaseState::num_local_chunks_;i++){
-      expval += BaseState::qregs_[i].expval_pauli(qubits, pauli);
+    for(i=0;i<nrows;i++){
+      uint_t iChunk = i * (nrows+1);
+      if(BaseState::chunk_index_begin_[BaseState::distributed_rank_] <= iChunk && BaseState::chunk_index_end_[BaseState::distributed_rank_] > iChunk){  //on this process
+        expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits, pauli);
+      }
     }
   }
 

--- a/src/simulators/density_matrix/densitymatrix_thrust.hpp
+++ b/src/simulators/density_matrix/densitymatrix_thrust.hpp
@@ -119,7 +119,6 @@ public:
   // Apply a 3-qubit toffoli gate
   void apply_toffoli(const uint_t qctrl0, const uint_t qctrl1, const uint_t qtrgt);
 
-
   //-----------------------------------------------------------------------
   // Z-measurement outcome probabilities
   //-----------------------------------------------------------------------
@@ -137,6 +136,13 @@ public:
   // generating samples.
   virtual reg_t sample_measure(const std::vector<double> &rnds) const override;
 
+  //-----------------------------------------------------------------------
+  // Expectation Values
+  //-----------------------------------------------------------------------
+
+  // Return the expectation value of an N-qubit Pauli matrix.
+  // The Pauli is input as a length N string of I,X,Y,Z characters.
+  double expval_pauli(const reg_t &qubits, const std::string &pauli,const complex_t initial_phase=1.0) const;
 
 protected:
   // Construct a vectorized superoperator from a vectorized matrix
@@ -752,6 +758,135 @@ void DensityMatrixThrust<data_t>::apply_toffoli(const uint_t qctrl0,
 
 }
 
+//-----------------------------------------------------------------------
+// Expectation Values
+//-----------------------------------------------------------------------
+
+//special case Z only
+template <typename data_t>
+class expval_pauli_Z_func_dm : public GateFuncBase<data_t>
+{
+protected:
+  uint_t z_mask_;
+  uint_t diag_stride_;
+public:
+  expval_pauli_Z_func_dm(uint_t z,uint_t stride)
+  {
+    z_mask_ = z;
+    diag_stride_ = 1 + stride;
+  }
+
+  bool is_diagonal(void)
+  {
+    return true;
+  }
+  uint_t size(int num_qubits)
+  {
+    return diag_stride_ - 1;
+  }
+
+  __host__ __device__ double operator()(const uint_t &i) const
+  {
+    thrust::complex<data_t>* vec;
+    thrust::complex<data_t> q0;
+    double ret = 0.0;
+
+    vec = this->data_;
+    q0 = vec[i * diag_stride_];
+    ret = q0.real();
+
+    if(z_mask_ != 0){
+      if(pop_count_kernel(i & z_mask_) & 1)
+        ret = -ret;
+    }
+
+    return ret;
+  }
+  const char* name(void)
+  {
+    return "expval_pauli_Z";
+  }
+};
+
+template <typename data_t>
+class expval_pauli_XYZ_func_dm : public GateFuncBase<data_t>
+{
+protected:
+  uint_t x_mask_;
+  uint_t z_mask_;
+  uint_t mask_l_;
+  uint_t mask_u_;
+  thrust::complex<data_t> phase_;
+  uint_t rows_;
+public:
+  expval_pauli_XYZ_func_dm(uint_t x,uint_t z,uint_t x_max,std::complex<data_t> p,uint_t stride)
+  {
+    rows_ = stride;
+    x_mask_ = x;
+    z_mask_ = z;
+    phase_ = p;
+
+    mask_u_ = ~((1ull << (x_max+1)) - 1);
+    mask_l_ = (1ull << x_max) - 1;
+  }
+
+  uint_t size(int num_qubits)
+  {
+    return (rows_ >> 1);
+  }
+
+  __host__ __device__ double operator()(const uint_t &i) const
+  {
+    thrust::complex<data_t>* vec;
+    thrust::complex<data_t> q0;
+    double ret = 0.0;
+    uint_t idx_vec, idx_mat;
+
+    vec = this->data_;
+
+    idx_vec = ((i << 1) & mask_u_) | (i & mask_l_);
+    idx_mat = idx_vec ^ x_mask_ + rows_ * idx_vec;
+
+    q0 = vec[idx_mat];
+    q0 = 2 * phase_ * q0;
+    ret = q0.real();
+    if(z_mask_ != 0){
+      if(pop_count_kernel(idx_vec & z_mask_) & 1)
+        ret = -ret;
+    }
+    return ret;
+  }
+  const char* name(void)
+  {
+    return "expval_pauli_XYZ";
+  }
+};
+
+template <typename data_t>
+double DensityMatrixThrust<data_t>::expval_pauli(const reg_t &qubits,
+                                                 const std::string &pauli,const complex_t initial_phase) const 
+{
+  uint_t x_mask, z_mask, num_y, x_max;
+  std::tie(x_mask, z_mask, num_y, x_max) = pauli_masks_and_phase(qubits, pauli);
+
+  // Special case for only I Paulis
+  if (x_mask + z_mask == 0) {
+    return BaseMatrix::trace().real();
+  }
+
+  // specialize x_max == 0
+  if(x_mask == 0) {
+    return BaseVector::apply_function_sum(
+      expval_pauli_Z_func_dm<data_t>(z_mask, BaseMatrix::rows_) );
+  }
+
+  // Compute the overall phase of the operator.
+  // This is (-1j) ** number of Y terms modulo 4
+  auto phase = std::complex<data_t>(initial_phase);
+  add_y_phase(num_y, phase);
+  return BaseVector::apply_function_sum(
+    expval_pauli_XYZ_func_dm<data_t>(x_mask, z_mask, x_max, phase, BaseMatrix::rows_) );
+}
 
 //-----------------------------------------------------------------------
 // Z-measurement outcome probabilities

--- a/src/simulators/density_matrix/densitymatrix_thrust.hpp
+++ b/src/simulators/density_matrix/densitymatrix_thrust.hpp
@@ -130,7 +130,7 @@ public:
 
   // Return the Z-basis measurement outcome probabilities [P(0), ..., P(2^N-1)]
   // for measurement of N-qubits.
-  virtual std::vector<double> probabilities(const reg_t &qubits) const;
+  virtual std::vector<double> probabilities(const reg_t &qubits) const override;
 
   // Return M sampled outcomes for Z-basis measurement of all qubits
   // The input is a length M list of random reals between [0, 1) used for

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -353,7 +353,7 @@ bool State::check_measurement_opt(const std::vector<Operations::Op> &ops) const
 {
   for (const auto &op: ops)
   {
-    if (op.conditional || op.old_conditional)
+    if (op.conditional)
     {
       return false;
     }

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -910,7 +910,6 @@ rvector_t State::measure_probs(const reg_t &qubits) const {
 std::vector<reg_t> State::sample_measure(const reg_t &qubits,
                                          uint_t shots,
                                          RngEngine &rng) {
-
   // There are two alternative algorithms for sample measure
   // We choose the one that is optimal relative to the total number 
   // of qubits,and the number of shots.
@@ -973,11 +972,11 @@ sample_measure_using_probabilities(const reg_t &qubits,
   std::vector<reg_t> all_samples;
   all_samples.reserve(shots);
   for (int_t val : allbit_samples) {
-    reg_t allbit_sample = Utils::int2reg(val, 2, qreg_.num_qubits());
+    reg_t allbit_sample = Utils::int2reg(val, 2, qubits.size());
     reg_t sample;
     sample.reserve(qubits.size());
-    for (uint_t qubit : qubits) {
-      sample.push_back(allbit_sample[qubit]);
+    for (uint_t j=0; j<qubits.size(); j++){
+      sample.push_back(allbit_sample[j]);
     }
     all_samples.push_back(sample);
   }

--- a/src/simulators/statevector/chunk/chunk.hpp
+++ b/src/simulators/statevector/chunk/chunk.hpp
@@ -31,7 +31,7 @@ template <typename data_t>
 class Chunk 
 {
 protected:
-  mutable std::shared_ptr<ChunkContainer<data_t>> chunk_container_;   //pointer to chunk container
+  mutable std::weak_ptr<ChunkContainer<data_t>> chunk_container_;   //pointer to chunk container
   std::shared_ptr<Chunk<data_t>> cache_;                //pointer to cache chunk on device
   uint_t chunk_pos_;                    //position in container
   int place_;                           //container ID
@@ -51,20 +51,22 @@ public:
   }
   ~Chunk()
   {
+    if(cache_)
+      cache_.reset();
   }
 
   void set_device(void) const
   {
-    chunk_container_->set_device();
+    chunk_container_.lock()->set_device();
   }
   int device(void)
   {
-    return chunk_container_->device();
+    return chunk_container_.lock()->device();
   }
 
   std::shared_ptr<ChunkContainer<data_t>> container()
   {
-    return chunk_container_;
+    return chunk_container_.lock();
   }
 
   uint_t pos(void)
@@ -106,26 +108,29 @@ public:
   }
   void enable_omp(bool flg)
   {
-    chunk_container_->enable_omp(flg);
+    chunk_container_.lock()->enable_omp(flg);
   }
 
   void Set(uint_t i,const thrust::complex<data_t>& t)
   {
-    chunk_container_->Set(i + (chunk_pos_ << chunk_container_->chunk_bits()),t);
+    auto sel_chunk_container = chunk_container_.lock();
+    sel_chunk_container->Set(i + (chunk_pos_ << sel_chunk_container->chunk_bits()),t);
   }
   thrust::complex<data_t> Get(uint_t i) const
   {
-    return chunk_container_->Get(i + (chunk_pos_ << chunk_container_->chunk_bits()));
+    auto sel_chunk_container = chunk_container_.lock();
+    return sel_chunk_container->Get(i + (chunk_pos_ << sel_chunk_container->chunk_bits()));
   }
 
   thrust::complex<data_t>& operator[](uint_t i)
   {
-    return (*chunk_container_)[i + (chunk_pos_ << chunk_container_->chunk_bits())];
+    auto sel_chunk_container = chunk_container_.lock();
+    return (*sel_chunk_container)[i + (chunk_pos_ << sel_chunk_container->chunk_bits())];
   }
 
   thrust::complex<data_t>* pointer(void)
   {
-    return chunk_container_->chunk_pointer(chunk_pos_);
+    return chunk_container_.lock()->chunk_pointer(chunk_pos_);
   }
 
   void StoreMatrix(const std::vector<std::complex<double>>& mat)
@@ -134,7 +139,7 @@ public:
       cache_->StoreMatrix(mat);
     }
     else{
-      chunk_container_->StoreMatrix(mat,chunk_pos_);
+      chunk_container_.lock()->StoreMatrix(mat,chunk_pos_);
     }
   }
   void StoreUintParams(const std::vector<uint_t>& prm)
@@ -143,29 +148,29 @@ public:
       cache_->StoreUintParams(prm);
     }
     else{
-      chunk_container_->StoreUintParams(prm,chunk_pos_);
+      chunk_container_.lock()->StoreUintParams(prm,chunk_pos_);
     }
   }
 
   void CopyIn(std::shared_ptr<Chunk<data_t>> src)
   {
-    chunk_container_->CopyIn(src,chunk_pos_);
+    chunk_container_.lock()->CopyIn(src,chunk_pos_);
   }
   void CopyOut(std::shared_ptr<Chunk<data_t>> dest)
   {
-    chunk_container_->CopyOut(dest,chunk_pos_);
+    chunk_container_.lock()->CopyOut(dest,chunk_pos_);
   }
-  void CopyIn(thrust::complex<data_t>* src)
+  void CopyIn(thrust::complex<data_t>* src, uint_t size)
   {
-    chunk_container_->CopyIn(src,chunk_pos_);
+    chunk_container_.lock()->CopyIn(src, chunk_pos_, size);
   }
-  void CopyOut(thrust::complex<data_t>* dest)
+  void CopyOut(thrust::complex<data_t>* dest, uint_t size)
   {
-    chunk_container_->CopyOut(dest,chunk_pos_);
+    chunk_container_.lock()->CopyOut(dest, chunk_pos_, size);
   }
   void Swap(std::shared_ptr<Chunk<data_t>> src)
   {
-    chunk_container_->Swap(src,chunk_pos_);
+    chunk_container_.lock()->Swap(src,chunk_pos_);
   }
 
   template <typename Function>
@@ -175,7 +180,7 @@ public:
       cache_->Execute(func,count);
     }
     else{
-      chunk_container_->Execute(func,chunk_pos_,count);
+      chunk_container_.lock()->Execute(func,chunk_pos_,count);
     }
   }
 
@@ -186,39 +191,40 @@ public:
       return cache_->ExecuteSum(func,count);
     }
     else{
-      return chunk_container_->ExecuteSum(func,chunk_pos_,count);
+      return chunk_container_.lock()->ExecuteSum(func,chunk_pos_,count);
     }
   }
 
   void Zero(void)
   {
-    chunk_container_->Zero(chunk_pos_,chunk_container_->chunk_size());
+    auto sel_chunk_container = chunk_container_.lock();
+    sel_chunk_container->Zero(chunk_pos_,sel_chunk_container->chunk_size());
   }
 
   reg_t sample_measure(const std::vector<double> &rnds,uint_t stride = 1,bool dot = true) const
   {
-    return chunk_container_->sample_measure(chunk_pos_,rnds,stride,dot);
+    return chunk_container_.lock()->sample_measure(chunk_pos_,rnds,stride,dot);
   }
 
   thrust::complex<double> norm(uint_t stride = 1,bool dot = true) const
   {
-    return chunk_container_->norm(chunk_pos_,stride,dot);
+    return chunk_container_.lock()->norm(chunk_pos_,stride,dot);
   }
 
 #ifdef AER_THRUST_CUDA
   cudaStream_t stream(void)
   {
-    return std::static_pointer_cast<DeviceChunkContainer<data_t>>(chunk_container_)->stream(chunk_pos_);
+    return std::static_pointer_cast<DeviceChunkContainer<data_t>>(chunk_container_.lock())->stream(chunk_pos_);
   }
 #endif
 
   thrust::complex<double>* matrix_pointer(void)
   {
-    return chunk_container_->matrix_pointer(chunk_pos_);
+    return chunk_container_.lock()->matrix_pointer(chunk_pos_);
   }
   uint_t* param_pointer(void)
   {
-    return chunk_container_->param_pointer(chunk_pos_);
+    return chunk_container_.lock()->param_pointer(chunk_pos_);
   }
 
   void synchronize(void)
@@ -227,28 +233,33 @@ public:
       cache_->synchronize();
     }
     else{
-      chunk_container_->synchronize(chunk_pos_);
+      chunk_container_.lock()->synchronize(chunk_pos_);
     }
   }
 
   //set qubits to be blocked
   void set_blocked_qubits(const reg_t& qubits)
   {
-    chunk_container_->set_blocked_qubits(chunk_pos_,qubits);
+    chunk_container_.lock()->set_blocked_qubits(chunk_pos_,qubits);
   }
 
   //do all gates stored in queue
   void apply_blocked_gates(void)
   {
-    chunk_container_->apply_blocked_gates(chunk_pos_);
+    chunk_container_.lock()->apply_blocked_gates(chunk_pos_);
   }
 
   //queue gate for blocked execution
   void queue_blocked_gate(char gate,uint_t qubit,uint_t mask,const std::complex<double>* pMat = nullptr)
   {
-    chunk_container_->queue_blocked_gate(chunk_pos_,gate,qubit,mask,pMat);
+    chunk_container_.lock()->queue_blocked_gate(chunk_pos_,gate,qubit,mask,pMat);
   }
 
+  //get chopped vector
+  void chop_vector(std::complex<data_t>& vector, reg_t& index,double epsilon)
+  {
+    chunk_container_.lock()->chop_vector(chunk_pos_,vector,index,epsilon);
+  }
 };
 
 //------------------------------------------------------------------------------

--- a/src/simulators/statevector/chunk/chunk.hpp
+++ b/src/simulators/statevector/chunk/chunk.hpp
@@ -256,7 +256,7 @@ public:
   }
 
   //get chopped vector
-  void chop_vector(std::complex<data_t>& vector, reg_t& index,double epsilon)
+  void chop_vector(std::vector<std::complex<data_t>>& vector, reg_t& index,double epsilon)
   {
     chunk_container_.lock()->chop_vector(chunk_pos_,vector,index,epsilon);
   }

--- a/src/simulators/statevector/chunk/chunk.hpp
+++ b/src/simulators/statevector/chunk/chunk.hpp
@@ -31,7 +31,7 @@ template <typename data_t>
 class Chunk 
 {
 protected:
-  mutable std::shared_ptr<ChunkContainer<data_t>> chunk_container_;   //pointer to chunk container
+  mutable std::weak_ptr<ChunkContainer<data_t>> chunk_container_;   //pointer to chunk container
   std::shared_ptr<Chunk<data_t>> cache_;                //pointer to cache chunk on device
   uint_t chunk_pos_;                    //position in container
   int place_;                           //container ID
@@ -55,16 +55,16 @@ public:
 
   void set_device(void) const
   {
-    chunk_container_->set_device();
+    chunk_container_.lock()->set_device();
   }
   int device(void)
   {
-    return chunk_container_->device();
+    return chunk_container_.lock()->device();
   }
 
   std::shared_ptr<ChunkContainer<data_t>> container()
   {
-    return chunk_container_;
+    return chunk_container_.lock();
   }
 
   uint_t pos(void)
@@ -106,26 +106,29 @@ public:
   }
   void enable_omp(bool flg)
   {
-    chunk_container_->enable_omp(flg);
+    chunk_container_.lock()->enable_omp(flg);
   }
 
   void Set(uint_t i,const thrust::complex<data_t>& t)
   {
-    chunk_container_->Set(i + (chunk_pos_ << chunk_container_->chunk_bits()),t);
+    auto sel_chunk_container = chunk_container_.lock();
+    sel_chunk_container->Set(i + (chunk_pos_ << sel_chunk_container->chunk_bits()),t);
   }
   thrust::complex<data_t> Get(uint_t i) const
   {
-    return chunk_container_->Get(i + (chunk_pos_ << chunk_container_->chunk_bits()));
+    auto sel_chunk_container = chunk_container_.lock();
+    return sel_chunk_container->Get(i + (chunk_pos_ << sel_chunk_container->chunk_bits()));
   }
 
   thrust::complex<data_t>& operator[](uint_t i)
   {
-    return (*chunk_container_)[i + (chunk_pos_ << chunk_container_->chunk_bits())];
+    auto sel_chunk_container = chunk_container_.lock();
+    return (*sel_chunk_container)[i + (chunk_pos_ << sel_chunk_container->chunk_bits())];
   }
 
   thrust::complex<data_t>* pointer(void)
   {
-    return chunk_container_->chunk_pointer(chunk_pos_);
+    return chunk_container_.lock()->chunk_pointer(chunk_pos_);
   }
 
   void StoreMatrix(const std::vector<std::complex<double>>& mat)
@@ -134,7 +137,7 @@ public:
       cache_->StoreMatrix(mat);
     }
     else{
-      chunk_container_->StoreMatrix(mat,chunk_pos_);
+      chunk_container_.lock()->StoreMatrix(mat,chunk_pos_);
     }
   }
   void StoreUintParams(const std::vector<uint_t>& prm)
@@ -143,29 +146,29 @@ public:
       cache_->StoreUintParams(prm);
     }
     else{
-      chunk_container_->StoreUintParams(prm,chunk_pos_);
+      chunk_container_.lock()->StoreUintParams(prm,chunk_pos_);
     }
   }
 
   void CopyIn(std::shared_ptr<Chunk<data_t>> src)
   {
-    chunk_container_->CopyIn(src,chunk_pos_);
+    chunk_container_.lock()->CopyIn(src,chunk_pos_);
   }
   void CopyOut(std::shared_ptr<Chunk<data_t>> dest)
   {
-    chunk_container_->CopyOut(dest,chunk_pos_);
+    chunk_container_.lock()->CopyOut(dest,chunk_pos_);
   }
   void CopyIn(thrust::complex<data_t>* src, uint_t size)
   {
-    chunk_container_->CopyIn(src,chunk_pos_, size);
+    chunk_container_.lock()->CopyIn(src, chunk_pos_, size);
   }
   void CopyOut(thrust::complex<data_t>* dest, uint_t size)
   {
-    chunk_container_->CopyOut(dest,chunk_pos_, size);
+    chunk_container_.lock()->CopyOut(dest, chunk_pos_, size);
   }
   void Swap(std::shared_ptr<Chunk<data_t>> src)
   {
-    chunk_container_->Swap(src,chunk_pos_);
+    chunk_container_.lock()->Swap(src,chunk_pos_);
   }
 
   template <typename Function>
@@ -175,7 +178,7 @@ public:
       cache_->Execute(func,count);
     }
     else{
-      chunk_container_->Execute(func,chunk_pos_,count);
+      chunk_container_.lock()->Execute(func,chunk_pos_,count);
     }
   }
 
@@ -186,39 +189,40 @@ public:
       return cache_->ExecuteSum(func,count);
     }
     else{
-      return chunk_container_->ExecuteSum(func,chunk_pos_,count);
+      return chunk_container_.lock()->ExecuteSum(func,chunk_pos_,count);
     }
   }
 
   void Zero(void)
   {
-    chunk_container_->Zero(chunk_pos_,chunk_container_->chunk_size());
+    auto sel_chunk_container = chunk_container_.lock();
+    sel_chunk_container->Zero(chunk_pos_,sel_chunk_container->chunk_size());
   }
 
   reg_t sample_measure(const std::vector<double> &rnds,uint_t stride = 1,bool dot = true) const
   {
-    return chunk_container_->sample_measure(chunk_pos_,rnds,stride,dot);
+    return chunk_container_.lock()->sample_measure(chunk_pos_,rnds,stride,dot);
   }
 
   thrust::complex<double> norm(uint_t stride = 1,bool dot = true) const
   {
-    return chunk_container_->norm(chunk_pos_,stride,dot);
+    return chunk_container_.lock()->norm(chunk_pos_,stride,dot);
   }
 
 #ifdef AER_THRUST_CUDA
   cudaStream_t stream(void)
   {
-    return std::static_pointer_cast<DeviceChunkContainer<data_t>>(chunk_container_)->stream(chunk_pos_);
+    return std::static_pointer_cast<DeviceChunkContainer<data_t>>(chunk_container_.lock())->stream(chunk_pos_);
   }
 #endif
 
   thrust::complex<double>* matrix_pointer(void)
   {
-    return chunk_container_->matrix_pointer(chunk_pos_);
+    return chunk_container_.lock()->matrix_pointer(chunk_pos_);
   }
   uint_t* param_pointer(void)
   {
-    return chunk_container_->param_pointer(chunk_pos_);
+    return chunk_container_.lock()->param_pointer(chunk_pos_);
   }
 
   void synchronize(void)
@@ -227,26 +231,26 @@ public:
       cache_->synchronize();
     }
     else{
-      chunk_container_->synchronize(chunk_pos_);
+      chunk_container_.lock()->synchronize(chunk_pos_);
     }
   }
 
   //set qubits to be blocked
   void set_blocked_qubits(const reg_t& qubits)
   {
-    chunk_container_->set_blocked_qubits(chunk_pos_,qubits);
+    chunk_container_.lock()->set_blocked_qubits(chunk_pos_,qubits);
   }
 
   //do all gates stored in queue
   void apply_blocked_gates(void)
   {
-    chunk_container_->apply_blocked_gates(chunk_pos_);
+    chunk_container_.lock()->apply_blocked_gates(chunk_pos_);
   }
 
   //queue gate for blocked execution
   void queue_blocked_gate(char gate,uint_t qubit,uint_t mask,const std::complex<double>* pMat = nullptr)
   {
-    chunk_container_->queue_blocked_gate(chunk_pos_,gate,qubit,mask,pMat);
+    chunk_container_.lock()->queue_blocked_gate(chunk_pos_,gate,qubit,mask,pMat);
   }
 
 };

--- a/src/simulators/statevector/chunk/chunk.hpp
+++ b/src/simulators/statevector/chunk/chunk.hpp
@@ -155,13 +155,13 @@ public:
   {
     chunk_container_->CopyOut(dest,chunk_pos_);
   }
-  void CopyIn(thrust::complex<data_t>* src)
+  void CopyIn(thrust::complex<data_t>* src, uint_t size)
   {
-    chunk_container_->CopyIn(src,chunk_pos_);
+    chunk_container_->CopyIn(src,chunk_pos_, size);
   }
-  void CopyOut(thrust::complex<data_t>* dest)
+  void CopyOut(thrust::complex<data_t>* dest, uint_t size)
   {
-    chunk_container_->CopyOut(dest,chunk_pos_);
+    chunk_container_->CopyOut(dest,chunk_pos_, size);
   }
   void Swap(std::shared_ptr<Chunk<data_t>> src)
   {

--- a/src/simulators/statevector/chunk/chunk_container.hpp
+++ b/src/simulators/statevector/chunk/chunk_container.hpp
@@ -320,6 +320,19 @@ struct complex_less
     __host__ __device__ bool operator()(const thrust::complex<data_t> &lhs, const thrust::complex<data_t> &rhs) const {return lhs.real() < rhs.real();}
 }; // end less
 
+template <typename data_t>
+class complex_epsilon
+{
+protected:
+  data_t epsilon_;
+public:
+  complex_epsilon(data_t eps)
+  {
+    epsilon_ = eps;
+  }
+  __host__ __device__
+    bool operator()(thrust::complex<data_t>& x) { return (thrust::abs(x) > epsilon_); }
+};
 
 //============================================================================
 // chunk container base class
@@ -443,6 +456,8 @@ public:
   virtual reg_t sample_measure(uint_t iChunk,const std::vector<double> &rnds, uint_t stride = 1, bool dot = true) const = 0;
   virtual thrust::complex<double> norm(uint_t iChunk,uint_t stride = 1,bool dot = true) const = 0;
 
+  //get chopped vector
+  virtual void chop_vector(uint_t iChunk, std::complex<data_t>& vector, reg_t& index,double epsilon) = 0;
 
   size_t size_of_complex(void)
   {

--- a/src/simulators/statevector/chunk/chunk_container.hpp
+++ b/src/simulators/statevector/chunk/chunk_container.hpp
@@ -312,7 +312,7 @@ public:
     epsilon_ = eps;
   }
   __host__ __device__
-    bool operator()(thrust::complex<data_t>& x) { return (thrust::abs(x) > epsilon_); }
+    bool operator()(const thrust::complex<data_t> x) { return (thrust::abs(x) > epsilon_); }
 };
 
 //============================================================================
@@ -438,7 +438,7 @@ public:
   virtual thrust::complex<double> norm(uint_t iChunk,uint_t stride = 1,bool dot = true) const = 0;
 
   //get chopped vector
-  virtual void chop_vector(uint_t iChunk, std::complex<data_t>& vector, reg_t& index,double epsilon) = 0;
+  virtual void chop_vector(uint_t iChunk, std::vector<std::complex<data_t>>& vector, reg_t& index,double epsilon) = 0;
 
   size_t size_of_complex(void)
   {

--- a/src/simulators/statevector/chunk/chunk_container.hpp
+++ b/src/simulators/statevector/chunk/chunk_container.hpp
@@ -428,8 +428,8 @@ public:
 
   virtual void CopyIn(std::shared_ptr<Chunk<data_t>> src,uint_t iChunk) = 0;
   virtual void CopyOut(std::shared_ptr<Chunk<data_t>> dest,uint_t iChunk) = 0;
-  virtual void CopyIn(thrust::complex<data_t>* src,uint_t iChunk) = 0;
-  virtual void CopyOut(thrust::complex<data_t>* dest,uint_t iChunk) = 0;
+  virtual void CopyIn(thrust::complex<data_t>* src,uint_t iChunk, uint_t size) = 0;
+  virtual void CopyOut(thrust::complex<data_t>* dest,uint_t iChunk, uint_t size) = 0;
   virtual void Swap(std::shared_ptr<Chunk<data_t>> src,uint_t iChunk) = 0;
 
   virtual void Zero(uint_t iChunk,uint_t count) = 0;

--- a/src/simulators/statevector/chunk/chunk_container.hpp
+++ b/src/simulators/statevector/chunk/chunk_container.hpp
@@ -16,34 +16,15 @@
 #ifndef _qv_chunk_container_hpp_
 #define _qv_chunk_container_hpp_
 
+#include "misc/warnings.hpp"
+DISABLE_WARNING_PUSH
 #ifdef AER_THRUST_CUDA
 #include <cuda.h>
 #include <cuda_runtime.h>
 #endif
+DISABLE_WARNING_POP
 
-#include <thrust/for_each.h>
-#include <thrust/complex.h>
-#include <thrust/inner_product.h>
-#include <thrust/transform.h>
-#include <thrust/transform_scan.h>
-#include <thrust/binary_search.h>
-#include <thrust/execution_policy.h>
-#include <thrust/functional.h>
-#include <thrust/tuple.h>
-#include <thrust/iterator/constant_iterator.h>
-#include <thrust/detail/vector_base.h>
-
-#include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/transform_iterator.h>
-#include <thrust/iterator/permutation_iterator.h>
-#include <thrust/fill.h>
-
-#ifdef AER_THRUST_CUDA
-#include <thrust/device_vector.h>
-#endif
-#include <thrust/host_vector.h>
-
-#include <thrust/system/omp/execution_policy.h>
+#include "misc/wrap_thrust.hpp"
 
 #include <algorithm>
 #include <array>

--- a/src/simulators/statevector/chunk/device_chunk_container.hpp
+++ b/src/simulators/statevector/chunk/device_chunk_container.hpp
@@ -181,7 +181,7 @@ public:
   void queue_blocked_gate(uint_t iChunk,char gate,uint_t qubit,uint_t mask,const std::complex<double>* pMat = NULL);
 
   //get chopped vector
-  void chop_vector(uint_t iChunk, std::complex<data_t>& vector, reg_t& index,double epsilon);
+  void chop_vector(uint_t iChunk, std::vector<std::complex<data_t>>& vector, reg_t& index,double epsilon);
 };
 
 template <typename data_t>
@@ -1157,7 +1157,7 @@ void DeviceChunkContainer<data_t>::apply_blocked_gates(uint_t iChunk)
 
 
 template <typename data_t>
-void DeviceChunkContainer<data_t>::chop_vector(uint_t iChunk, std::complex<data_t>& vector, reg_t& index,double epsilon)
+void DeviceChunkContainer<data_t>::chop_vector(uint_t iChunk, std::vector<std::complex<data_t>>& vector, reg_t& index,double epsilon)
 {
   std::shared_ptr<Chunk<data_t>> buffer;
   thrust::complex<data_t>* pRet;
@@ -1167,7 +1167,7 @@ void DeviceChunkContainer<data_t>::chop_vector(uint_t iChunk, std::complex<data_
   buffer = this->MapBufferChunk();    //use buffer chunk for temporary to save chopped vector
 
   //chop vector
-  pRet = thrust::copy_if(thrust::device, data_.begin() + (iChunk << this->chunk_bits_), data_.begin() + ((iChunk+1) << this->chunk_bits_),buffer->pointer(), complex_epsilon((data_t)epsilon));
+  pRet = thrust::copy_if(thrust::device, data_.begin() + (iChunk << this->chunk_bits_), data_.begin() + ((iChunk+1) << this->chunk_bits_),buffer->pointer(), complex_epsilon<data_t>((data_t)epsilon));
   uint_t nchop = (uint_t)(pRet - buffer->pointer());
 
   vector.resize(nchop);
@@ -1183,7 +1183,7 @@ void DeviceChunkContainer<data_t>::chop_vector(uint_t iChunk, std::complex<data_
   thrust::sequence(thrust::device,pSeq,pSeq+(1ull << this->chunk_bits_));
 
   //get index for chopped vector
-  thrust::copy_if(thrust::device, pSeq, pSeq+(1ull << this->chunk_bits_),data_.begin() + (iChunk << this->chunk_bits_),pIndex, complex_epsilon((data_t)epsilon));
+  thrust::copy_if(thrust::device, pSeq, pSeq+(1ull << this->chunk_bits_),data_.begin() + (iChunk << this->chunk_bits_),pIndex, complex_epsilon<data_t>((data_t)epsilon));
   thrust::copy_n(pIndex,nchop,&index[0]);
 
   this->UnmapBuffer(buffer);

--- a/src/simulators/statevector/chunk/device_chunk_container.hpp
+++ b/src/simulators/statevector/chunk/device_chunk_container.hpp
@@ -129,8 +129,8 @@ public:
 
   void CopyIn(std::shared_ptr<Chunk<data_t>> src,uint_t iChunk);
   void CopyOut(std::shared_ptr<Chunk<data_t>> src,uint_t iChunk);
-  void CopyIn(thrust::complex<data_t>* src,uint_t iChunk);
-  void CopyOut(thrust::complex<data_t>* dest,uint_t iChunk);
+  void CopyIn(thrust::complex<data_t>* src,uint_t iChunk, uint_t size);
+  void CopyOut(thrust::complex<data_t>* dest,uint_t iChunk, uint_t size);
   void Swap(std::shared_ptr<Chunk<data_t>> src,uint_t iChunk);
 
   void Zero(uint_t iChunk,uint_t count);
@@ -502,18 +502,21 @@ void DeviceChunkContainer<data_t>::CopyOut(std::shared_ptr<Chunk<data_t>> dest,u
 }
 
 template <typename data_t>
-void DeviceChunkContainer<data_t>::CopyIn(thrust::complex<data_t>* src,uint_t iChunk)
+void DeviceChunkContainer<data_t>::CopyIn(thrust::complex<data_t>* src,uint_t iChunk, uint_t size)
 {
-  uint_t size = 1ull << this->chunk_bits_;
+  uint_t this_size = 1ull << this->chunk_bits_;
+  if(this_size < size) throw std::runtime_error("CopyIn chunk size is less than provided size");
+  
   set_device();
-
   thrust::copy_n(src,size,data_.begin() + (iChunk << this->chunk_bits_));
 }
 
 template <typename data_t>
-void DeviceChunkContainer<data_t>::CopyOut(thrust::complex<data_t>* dest,uint_t iChunk)
+void DeviceChunkContainer<data_t>::CopyOut(thrust::complex<data_t>* dest,uint_t iChunk, uint_t size)
 {
-  uint_t size = 1ull << this->chunk_bits_;
+  uint_t this_size = 1ull << this->chunk_bits_;
+  if(this_size < size) throw std::runtime_error("CopyOut chunk size is less than provided size");
+  
   set_device();
   thrust::copy_n(data_.begin() + (iChunk << this->chunk_bits_),size,dest);
 }

--- a/src/simulators/statevector/chunk/host_chunk_container.hpp
+++ b/src/simulators/statevector/chunk/host_chunk_container.hpp
@@ -103,8 +103,8 @@ public:
 
   void CopyIn(std::shared_ptr<Chunk<data_t>> src,uint_t iChunk);
   void CopyOut(std::shared_ptr<Chunk<data_t>> src,uint_t iChunk);
-  void CopyIn(thrust::complex<data_t>* src,uint_t iChunk);
-  void CopyOut(thrust::complex<data_t>* dest,uint_t iChunk);
+  void CopyIn(thrust::complex<data_t>* src,uint_t iChunk, uint_t size);
+  void CopyOut(thrust::complex<data_t>* dest,uint_t iChunk, uint_t size);
   void Swap(std::shared_ptr<Chunk<data_t>> src,uint_t iChunk);
 
   void Zero(uint_t iChunk,uint_t count);
@@ -234,17 +234,20 @@ void HostChunkContainer<data_t>::CopyOut(std::shared_ptr<Chunk<data_t>> dest,uin
 }
 
 template <typename data_t>
-void HostChunkContainer<data_t>::CopyIn(thrust::complex<data_t>* src,uint_t iChunk)
+void HostChunkContainer<data_t>::CopyIn(thrust::complex<data_t>* src,uint_t iChunk, uint_t size)
 {
-  uint_t size = 1ull << this->chunk_bits_;
-
+  uint_t this_size = 1ull << this->chunk_bits_;
+  if(this_size < size) throw std::runtime_error("CopyIn chunk size is less than provided size");
+  
   thrust::copy_n(src,size,data_.begin() + (iChunk << this->chunk_bits_));
 }
 
 template <typename data_t>
-void HostChunkContainer<data_t>::CopyOut(thrust::complex<data_t>* dest,uint_t iChunk)
+void HostChunkContainer<data_t>::CopyOut(thrust::complex<data_t>* dest,uint_t iChunk, uint_t size)
 {
-  uint_t size = 1ull << this->chunk_bits_;
+  uint_t this_size = 1ull << this->chunk_bits_;
+  if(this_size < size) throw std::runtime_error("CopyIn chunk size is less than provided size");
+  
   thrust::copy_n(data_.begin() + (iChunk << this->chunk_bits_),size,dest);
 }
 

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -308,14 +308,12 @@ public:
 
   // Return the expectation value of an N-qubit Pauli matrix.
   // The Pauli is input as a length N string of I,X,Y,Z characters.
-  double expval_pauli(const reg_t &qubits, const std::string &pauli,
-                      const complex_t &coeff = 1) const;
+  double expval_pauli(const reg_t &qubits, const std::string &pauli,const complex_t initial_phase=1.0) const;
   //for multi-chunk inter chunk expectation
   double expval_pauli(const reg_t &qubits, const std::string &pauli,
                       const QubitVector<data_t>& pair_chunk, 
                       const uint_t z_count,
-                      const uint_t z_count_pair,
-                      const complex_t &coeff = 1) const;
+                      const uint_t z_count_pair,const complex_t initial_phase=1.0) const;
 
   //-----------------------------------------------------------------------
   // JSON configuration settings
@@ -1966,8 +1964,7 @@ void add_y_phase(uint_t num_y, std::complex<data_t>& coeff){
 
 template <typename data_t>
 double QubitVector<data_t>::expval_pauli(const reg_t &qubits,
-                                         const std::string &pauli,
-                                         const complex_t &coeff) const {
+                                         const std::string &pauli,const complex_t initial_phase) const {
 
   uint_t x_mask, z_mask, num_y, x_max;
   std::tie(x_mask, z_mask, num_y, x_max) = pauli_masks_and_phase(qubits, pauli);
@@ -1976,7 +1973,7 @@ double QubitVector<data_t>::expval_pauli(const reg_t &qubits,
   if (x_mask + z_mask == 0) {
     return norm();
   }
-  auto phase = std::complex<data_t>(coeff);
+  auto phase = std::complex<data_t>(initial_phase);
   add_y_phase(num_y, phase);
 
   // specialize x_max == 0
@@ -2018,14 +2015,13 @@ template <typename data_t>
 double QubitVector<data_t>::expval_pauli(const reg_t &qubits,
                                          const std::string &pauli,
                                          const QubitVector<data_t>& pair_chunk,
-                                         const uint_t z_count,const uint_t z_count_pair,
-                                         const complex_t &coeff) const 
+                                         const uint_t z_count,const uint_t z_count_pair,const complex_t initial_phase) const 
 {
 
   uint_t x_mask, z_mask, num_y, x_max;
   std::tie(x_mask, z_mask, num_y, x_max) = pauli_masks_and_phase(qubits, pauli);
 
-  auto phase = std::complex<data_t>(coeff);
+  auto phase = std::complex<data_t>(initial_phase);
   add_y_phase(num_y, phase);
 
   std::complex<data_t>* pair_ptr = pair_chunk.data();

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -625,7 +625,7 @@ cvector_t<data_t> QubitVectorThrust<data_t>::vector() const
 template <typename data_t>
 cdict_t<data_t> QubitVectorThrust<data_t>::vector_ket(double epsilon) const
 {
-  std::vector<complex<data_t>> vector;
+  std::vector<std::complex<data_t>> vector;
   reg_t index;
   chunk_->chop_vector(vector,index,epsilon);
   return AER::Utils::vec2ket(vector, index, data_size_, 16);

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -625,9 +625,12 @@ cvector_t<data_t> QubitVectorThrust<data_t>::vector() const
 }
 
 template <typename data_t>
-cdict_t<data_t> QubitVectorThrust<data_t>::vector_ket(double epsilon) const{
-    // non-optimized version; relies on creating a copy of the statevector
-    return AER::Utils::vec2ket(vector(), epsilon, 16);
+cdict_t<data_t> QubitVectorThrust<data_t>::vector_ket(double epsilon) const
+{
+  std::vector<complex<data_t>> vector;
+  reg_t index;
+  chunk_->chop_vector(vector,index,epsilon);
+  return AER::Utils::vec2ket(vector, index, data_size_, 16);
 }
 
 template <typename data_t>

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -313,13 +313,11 @@ public:
 
   // Return the expectation value of an N-qubit Pauli matrix.
   // The Pauli is input as a length N string of I,X,Y,Z characters.
-  double expval_pauli(const reg_t &qubits, const std::string &pauli,
-                      const complex_t &coeff = 1) const;
+  double expval_pauli(const reg_t &qubits, const std::string &pauli,const complex_t initial_phase=1.0) const;
   //for multi-chunk inter chunk expectation
   double expval_pauli(const reg_t &qubits, const std::string &pauli,
                       const QubitVectorThrust<data_t>& pair_chunk,
-                      const uint_t z_count,const uint_t z_count_pair,
-                      const complex_t &coeff = 1) const;
+                      const uint_t z_count,const uint_t z_count_pair,const complex_t initial_phase=1.0) const;
 
 
   //-----------------------------------------------------------------------
@@ -3459,12 +3457,11 @@ class expval_pauli_Z_func : public GateFuncBase<data_t>
 {
 protected:
   uint_t z_mask_;
-  thrust::complex<data_t> phase_;
+
 public:
-  expval_pauli_Z_func(uint_t z,std::complex<data_t> p)
+  expval_pauli_Z_func(uint_t z)
   {
     z_mask_ = z;
-    phase_ = p;
   }
 
   bool is_diagonal(void)
@@ -3481,7 +3478,6 @@ public:
     vec = this->data_;
 
     q0 = vec[i];
-    q0 = phase_ * q0;
     ret = q0.real()*q0.real() + q0.imag()*q0.imag();
 
     if(z_mask_ != 0){
@@ -3563,8 +3559,7 @@ public:
 
 template <typename data_t>
 double QubitVectorThrust<data_t>::expval_pauli(const reg_t &qubits,
-                                               const std::string &pauli,
-                                               const complex_t &coeff) const 
+                                               const std::string &pauli,const complex_t initial_phase) const 
 {
   uint_t x_mask, z_mask, num_y, x_max;
   std::tie(x_mask, z_mask, num_y, x_max) = pauli_masks_and_phase(qubits, pauli);
@@ -3573,17 +3568,16 @@ double QubitVectorThrust<data_t>::expval_pauli(const reg_t &qubits,
   if (x_mask + z_mask == 0) {
     return norm();
   }
+  
+  // specialize x_max == 0
+  if(x_mask == 0) {
+    return apply_function_sum( expval_pauli_Z_func<data_t>(z_mask) );
+  }
 
   // Compute the overall phase of the operator.
   // This is (-1j) ** number of Y terms modulo 4
-  auto phase = std::complex<data_t>(coeff);
+  auto phase = std::complex<data_t>(initial_phase);
   add_y_phase(num_y, phase);
-
-  // specialize x_max == 0
-  if(x_mask == 0) {
-    return apply_function_sum( expval_pauli_Z_func<data_t>(z_mask, phase) );
-  }
-
   return apply_function_sum( expval_pauli_XYZ_func<data_t>(x_mask, z_mask, x_max, phase) );
 }
 
@@ -3655,8 +3649,7 @@ template <typename data_t>
 double QubitVectorThrust<data_t>::expval_pauli(const reg_t &qubits,
                                                const std::string &pauli,
                                                const QubitVectorThrust<data_t>& pair_chunk,
-                                               const uint_t z_count,const uint_t z_count_pair,
-                                               const complex_t &coeff) const 
+                                               const uint_t z_count,const uint_t z_count_pair,const complex_t initial_phase) const 
 {
   uint_t x_mask, z_mask, num_y, x_max;
   std::tie(x_mask, z_mask, num_y, x_max) = pauli_masks_and_phase(qubits, pauli);
@@ -3709,7 +3702,7 @@ double QubitVectorThrust<data_t>::expval_pauli(const reg_t &qubits,
 
   // Compute the overall phase of the operator.
   // This is (-1j) ** number of Y terms modulo 4
-  auto phase = std::complex<data_t>(coeff);
+  auto phase = std::complex<data_t>(initial_phase);
   add_y_phase(num_y, phase);
 
   ret = apply_function_sum( expval_pauli_inter_chunk_func<data_t>(x_mask, z_mask, phase, pair_ptr,z_count,z_count_pair) );

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -613,7 +613,7 @@ cvector_t<data_t> QubitVectorThrust<data_t>::vector() const
 {
   cvector_t<data_t> ret(data_size_, 0.);
 
-  chunk_->CopyOut((thrust::complex<data_t>*)&ret[0]);
+  chunk_->CopyOut((thrust::complex<data_t>*)&ret[0], data_size_);
 
 #ifdef AER_DEBUG
   DebugMsg("vector");
@@ -626,7 +626,7 @@ template <typename data_t>
 AER::Vector<std::complex<data_t>> QubitVectorThrust<data_t>::copy_to_vector() const 
 {
   cvector_t<data_t> ret(data_size_, 0.);
-  chunk_->CopyOut((thrust::complex<data_t>*)&ret[0]);
+  chunk_->CopyOut((thrust::complex<data_t>*)&ret[0], data_size_);
 
 #ifdef AER_DEBUG
   DebugMsg("copy_to_vector");
@@ -641,7 +641,7 @@ AER::Vector<std::complex<data_t>> QubitVectorThrust<data_t>::move_to_vector()
   std::complex<data_t>* pRet;
   pRet = reinterpret_cast<std::complex<data_t>*>(malloc(sizeof(std::complex<data_t>) * data_size_));
 
-  chunk_->CopyOut((thrust::complex<data_t>*)pRet);
+  chunk_->CopyOut((thrust::complex<data_t>*)pRet, data_size_);
 
   const auto vec = AER::Vector<std::complex<data_t>>::move_from_buffer(data_size_, pRet);
 
@@ -1106,7 +1106,7 @@ void QubitVectorThrust<data_t>::initialize_from_vector(const cvector_t<double> &
     tmp[i] = statevec[i];
   }
 
-  chunk_->CopyIn((thrust::complex<data_t>*)&tmp[0]);
+  chunk_->CopyIn((thrust::complex<data_t>*)&tmp[0], data_size_);
 
 #ifdef AER_DEBUG
   DebugMsg("initialize_from_vector");
@@ -1127,7 +1127,7 @@ void QubitVectorThrust<data_t>::initialize_from_data(const std::complex<data_t>*
   DebugMsg("calling initialize_from_data");
 #endif
 
-  chunk_->CopyIn((thrust::complex<data_t>*)(statevec));
+  chunk_->CopyIn((thrust::complex<data_t>*)(statevec), data_size_);
 
 #ifdef AER_DEBUG
   DebugMsg("initialize_from_data");

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -149,7 +149,7 @@ public:
   virtual std::vector<reg_t> sample_measure(const reg_t &qubits, uint_t shots,
                                             RngEngine &rng) override;
 
-  virtual void allocate(uint_t num_qubits);
+  virtual void allocate(uint_t num_qubits) override;
 
   //-----------------------------------------------------------------------
   // Additional methods

--- a/src/simulators/statevector/statevector_state_chunk.hpp
+++ b/src/simulators/statevector/statevector_state_chunk.hpp
@@ -128,7 +128,7 @@ protected:
   virtual void apply_op(const int_t iChunk,const Operations::Op &op,
                          ExperimentResult &result,
                          RngEngine &rng,
-                         bool final_ops = false);
+                         bool final_ops = false) override;
 
   // Applies a sypported Gate operation to the state class.
   // If the input is not in allowed_gates an exeption will be raised.
@@ -455,7 +455,7 @@ template <class statevec_t>
 auto State<statevec_t>::move_to_vector()
 {
   if(BaseState::num_global_chunks_ == 1){
-    return BaseState::qregs_[0].move_to_vector();
+      return BaseState::qregs_[0].move_to_vector();
   }
   else{
     int_t iChunk;

--- a/src/simulators/statevector/statevector_state_chunk.hpp
+++ b/src/simulators/statevector/statevector_state_chunk.hpp
@@ -571,7 +571,7 @@ double State<statevec_t>::expval_pauli(const reg_t &qubits,
   }
 
   if(qubits_out_chunk.size() > 0){  //there are bits out of chunk
-    std::complex<double> coeff = 1.0;
+    std::complex<double> phase = 1.0;
 
     std::reverse(pauli_out_chunk.begin(),pauli_out_chunk.end());
     std::reverse(pauli_in_chunk.begin(),pauli_in_chunk.end());
@@ -579,7 +579,7 @@ double State<statevec_t>::expval_pauli(const reg_t &qubits,
     uint_t x_mask, z_mask, num_y, x_max;
     std::tie(x_mask, z_mask, num_y, x_max) = AER::QV::pauli_masks_and_phase(qubits_out_chunk, pauli_out_chunk);
 
-    AER::QV::add_y_phase(num_y,coeff);
+    AER::QV::add_y_phase(num_y,phase);
 
     if(x_mask != 0){    //pairing state is out of chunk
       bool on_same_process = true;
@@ -618,12 +618,12 @@ double State<statevec_t>::expval_pauli(const reg_t &qubits,
           z_count_pair = AER::Utils::popcount(pair_chunk & z_mask);
 
           if(iProc == BaseState::distributed_rank_){  //pair is on the same process
-            expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[pair_chunk - BaseState::global_chunk_index_],z_count,z_count_pair,coeff);
+            expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[pair_chunk - BaseState::global_chunk_index_],z_count,z_count_pair);
           }
           else{
             BaseState::recv_chunk(iChunk-BaseState::global_chunk_index_,pair_chunk);
             //refer receive buffer to calculate expectation value
-            expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[iChunk-BaseState::global_chunk_index_],z_count,z_count_pair,coeff);
+            expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[iChunk-BaseState::global_chunk_index_],z_count,z_count_pair);
           }
         }
         else if(iProc == BaseState::distributed_rank_){  //pair is on this process
@@ -638,7 +638,7 @@ double State<statevec_t>::expval_pauli(const reg_t &qubits,
         double sign = 1.0;
         if (z_mask && (AER::Utils::popcount((i + BaseState::global_chunk_index_) & z_mask) & 1))
           sign = -1.0;
-        expval += sign * BaseState::qregs_[i].expval_pauli(qubits_in_chunk, pauli_in_chunk,coeff);
+        expval += sign * BaseState::qregs_[i].expval_pauli(qubits_in_chunk, pauli_in_chunk);
       }
     }
   }

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -104,7 +104,7 @@ public:
   // Config: {"omp_qubit_threshold": 7}
   virtual void set_config(const json_t &config) override;
 
-  virtual void allocate(uint_t num_qubits);
+  virtual void allocate(uint_t num_qubits) override;
 
   //-----------------------------------------------------------------------
   // Additional methods

--- a/src/simulators/unitary/unitary_state_chunk.hpp
+++ b/src/simulators/unitary/unitary_state_chunk.hpp
@@ -111,7 +111,7 @@ protected:
   virtual void apply_op(const int_t iChunk,const Operations::Op &op,
                          ExperimentResult &result,
                          RngEngine &rng,
-                         bool final_ops = false);
+                         bool final_ops = false) override;
 
   // Applies a Gate operation to the state class.
   // This should support all and only the operations defined in
@@ -166,7 +166,7 @@ protected:
   // Threshold for chopping small values to zero in JSON
   double json_chop_threshold_ = 1e-10;
 
-  int qubit_scale(void)
+  int qubit_scale() override
   {
     return 2;
   }

--- a/src/simulators/unitary/unitarymatrix_thrust.hpp
+++ b/src/simulators/unitary/unitarymatrix_thrust.hpp
@@ -58,7 +58,7 @@ public:
 #endif
 
   // Set the size of the vector in terms of qubit number
-  void set_num_qubits(size_t num_qubits);
+  void set_num_qubits(size_t num_qubits) override;
 
   // Return the number of rows in the matrix
   size_t num_rows() const {return rows_;}

--- a/src/simulators/unitary/unitarymatrix_thrust.hpp
+++ b/src/simulators/unitary/unitarymatrix_thrust.hpp
@@ -268,7 +268,7 @@ void UnitaryMatrixThrust<data_t>::initialize_from_matrix(const AER::cmatrix_t &m
       tmp[row + nrows * col] = mat(row, col);
     }
 
-  BaseVector::chunk_->CopyIn((thrust::complex<data_t>*)&tmp[0]);
+  BaseVector::chunk_->CopyIn((thrust::complex<data_t>*)&tmp[0], BaseVector::data_size_);
 }
 
 template <class data_t>

--- a/src/transpile/cacheblocking.hpp
+++ b/src/transpile/cacheblocking.hpp
@@ -54,7 +54,7 @@ public:
                         const opset_t &allowed_opset,
                         ExperimentResult &result) const override;
 
-  void set_config(const json_t &config);
+  void set_config(const json_t &config) override;
   bool enabled()
   {
     return blocking_enabled_;

--- a/test/terra/backends/qasm_simulator/qasm_save_expval.py
+++ b/test/terra/backends/qasm_simulator/qasm_save_expval.py
@@ -16,10 +16,14 @@ QasmSimulator Integration Tests for SaveExpval instruction
 from ddt import ddt, data
 from numpy import allclose
 import qiskit.quantum_info as qi
+from qiskit import QuantumCircuit
 from qiskit.circuit.library import QuantumVolume
 from qiskit.compiler import transpile, assemble
 
 from qiskit.providers.aer import QasmSimulator
+
+PAULI2 = ['II', 'IX', 'IY', 'IZ', 'XI', 'XX', 'XY', 'XZ',
+          'YI', 'YX', 'YY', 'YZ', 'ZI', 'ZX', 'ZY', 'ZZ']
 
 
 @ddt
@@ -29,8 +33,7 @@ class QasmSaveExpectationValueTests:
     SIMULATOR = QasmSimulator()
     BACKEND_OPTS = {}
 
-    @data('II', 'IX', 'IY', 'IZ', 'XI', 'XX', 'XY', 'XZ',
-          'YI', 'YX', 'YY', 'YZ', 'ZI', 'ZX', 'ZY', 'ZZ')
+    @data(*PAULI2)
     def test_save_expval_stabilizer_pauli(self, pauli):
         """Test Pauli expval for stabilizer circuit"""
 
@@ -62,8 +65,7 @@ class QasmSaveExpectationValueTests:
             value = result.data(0)['expval']
             self.assertAlmostEqual(value, target)
 
-    @data('II', 'IX', 'IY', 'IZ', 'XI', 'XX', 'XY', 'XZ',
-          'YI', 'YX', 'YY', 'YZ', 'ZI', 'ZX', 'ZY', 'ZZ')
+    @data(*PAULI2)
     def test_save_expval_var_stabilizer_pauli(self, pauli):
         """Test Pauli expval_var for stabilizer circuit"""
 
@@ -163,8 +165,7 @@ class QasmSaveExpectationValueTests:
             value = result.data(0)['expval']
             self.assertTrue(allclose(value, target))
 
-    @data('II', 'IX', 'IY', 'IZ', 'XI', 'XX', 'XY', 'XZ',
-          'YI', 'YX', 'YY', 'YZ', 'ZI', 'ZX', 'ZY', 'ZZ')
+    @data(*PAULI2)
     def test_save_expval_nonstabilizer_pauli(self, pauli):
         """Test Pauli expval for non-stabilizer circuit"""
 
@@ -195,8 +196,7 @@ class QasmSaveExpectationValueTests:
             value = result.data(0)['expval']
             self.assertAlmostEqual(value, target)
 
-    @data('II', 'IX', 'IY', 'IZ', 'XI', 'XX', 'XY', 'XZ',
-          'YI', 'YX', 'YY', 'YZ', 'ZI', 'ZX', 'ZY', 'ZZ')
+    @data(*PAULI2)
     def test_save_expval_var_nonstabilizer_pauli(self, pauli):
         """Test Pauli expval_var for non-stabilizer circuit"""
 
@@ -289,6 +289,72 @@ class QasmSaveExpectationValueTests:
         if method not in SUPPORTED_METHODS:
             self.assertFalse(result.success)
         else:
+            self.assertTrue(result.success)
+            value = result.data(0)['expval']
+            self.assertTrue(allclose(value, target))
+
+    @data(*PAULI2)
+    def test_save_expval_cptp_pauli(self, pauli):
+        """Test Pauli expval for stabilizer circuit"""
+
+        SUPPORTED_METHODS = [
+            'density_matrix', 'density_matrix_gpu', 'density_matrix_thrust'
+        ]
+        SEED = 5832
+
+        opts = self.BACKEND_OPTS.copy()
+        if opts.get('method') in SUPPORTED_METHODS:
+
+            oper = qi.Pauli(pauli)
+
+            # CPTP channel test circuit
+            channel = qi.random_quantum_channel(4, seed=SEED)
+            state_circ = QuantumCircuit(2)
+            state_circ.append(channel, range(2))
+
+            state = qi.DensityMatrix(state_circ)
+            target = state.expectation_value(oper).real.round(10)
+
+            # Snapshot circuit
+            circ = transpile(state_circ, self.SIMULATOR)
+            circ.save_expectation_value(oper, [0, 1], label='expval')
+            qobj = assemble(circ)
+            result = self.SIMULATOR.run(qobj, **opts).result()
+
+            self.assertTrue(result.success)
+            value = result.data(0)['expval']
+            self.assertAlmostEqual(value, target)
+
+    @data(*PAULI2)
+    def test_save_expval_var_cptp_pauli(self, pauli):
+        """Test Pauli expval_var for stabilizer circuit"""
+
+        SUPPORTED_METHODS = [
+            'density_matrix', 'density_matrix_gpu', 'density_matrix_thrust'
+        ]
+        SEED = 5832
+
+        opts = self.BACKEND_OPTS.copy()
+        if opts.get('method') in SUPPORTED_METHODS:
+
+            oper = qi.Pauli(pauli)
+
+            # CPTP channel test circuit
+            channel = qi.random_quantum_channel(4, seed=SEED)
+            state_circ = QuantumCircuit(2)
+            state_circ.append(channel, range(2))
+
+            state = qi.DensityMatrix(state_circ)
+            expval = state.expectation_value(oper).real
+            variance = state.expectation_value(oper ** 2).real - expval ** 2
+            target = [expval, variance]
+
+            # Snapshot circuit
+            circ = transpile(state_circ, self.SIMULATOR)
+            circ.save_expectation_value_variance(oper, [0, 1], label='expval')
+            qobj = assemble(circ)
+            result = self.SIMULATOR.run(qobj, **opts).result()
+
             self.assertTrue(result.success)
             value = result.data(0)['expval']
             self.assertTrue(allclose(value, target))

--- a/test/terra/backends/qasm_simulator/qasm_save_expval.py
+++ b/test/terra/backends/qasm_simulator/qasm_save_expval.py
@@ -46,9 +46,9 @@ class QasmSaveExpectationValueTests:
 
         # Stabilizer test circuit
         state_circ = qi.random_clifford(2, seed=SEED).to_circuit()
-        oper = qi.Pauli(pauli)
+        oper = qi.Operator(qi.Pauli(pauli))
         state = qi.Statevector(state_circ)
-        target = state.expectation_value(oper).real.round(10)
+        target = state.expectation_value(oper).real
 
         # Snapshot circuit
         opts = self.BACKEND_OPTS.copy()
@@ -78,7 +78,7 @@ class QasmSaveExpectationValueTests:
 
         # Stabilizer test circuit
         state_circ = qi.random_clifford(2, seed=SEED).to_circuit()
-        oper = qi.Pauli(pauli)
+        oper = qi.Operator(qi.Pauli(pauli))
         state = qi.Statevector(state_circ)
         expval = state.expectation_value(oper).real
         variance = state.expectation_value(oper ** 2).real - expval ** 2
@@ -178,9 +178,9 @@ class QasmSaveExpectationValueTests:
 
         # Stabilizer test circuit
         state_circ = QuantumVolume(2, 1, seed=SEED)
-        oper = qi.Pauli(pauli)
+        oper = qi.Operator(qi.Pauli(pauli))
         state = qi.Statevector(state_circ)
-        target = state.expectation_value(oper).real.round(10)
+        target = state.expectation_value(oper).real
 
         # Snapshot circuit
         opts = self.BACKEND_OPTS.copy()
@@ -209,7 +209,7 @@ class QasmSaveExpectationValueTests:
 
         # Stabilizer test circuit
         state_circ = QuantumVolume(2, 1, seed=SEED)
-        oper = qi.Pauli(pauli)
+        oper = qi.Operator(qi.Pauli(pauli))
         state = qi.Statevector(state_circ)
         expval = state.expectation_value(oper).real
         variance = state.expectation_value(oper ** 2).real - expval ** 2
@@ -244,7 +244,7 @@ class QasmSaveExpectationValueTests:
         state_circ = QuantumVolume(3, 1, seed=SEED)
         oper = qi.random_hermitian(4, traceless=True, seed=SEED)
         state = qi.Statevector(state_circ)
-        target = state.expectation_value(oper, qubits).real.round(10)
+        target = state.expectation_value(oper, qubits).real
 
         # Snapshot circuit
         opts = self.BACKEND_OPTS.copy()
@@ -305,7 +305,7 @@ class QasmSaveExpectationValueTests:
         opts = self.BACKEND_OPTS.copy()
         if opts.get('method') in SUPPORTED_METHODS:
 
-            oper = qi.Pauli(pauli)
+            oper = qi.Operator(qi.Pauli(pauli))
 
             # CPTP channel test circuit
             channel = qi.random_quantum_channel(4, seed=SEED)
@@ -313,7 +313,7 @@ class QasmSaveExpectationValueTests:
             state_circ.append(channel, range(2))
 
             state = qi.DensityMatrix(state_circ)
-            target = state.expectation_value(oper).real.round(10)
+            target = state.expectation_value(oper).real
 
             # Snapshot circuit
             circ = transpile(state_circ, self.SIMULATOR)
@@ -337,7 +337,7 @@ class QasmSaveExpectationValueTests:
         opts = self.BACKEND_OPTS.copy()
         if opts.get('method') in SUPPORTED_METHODS:
 
-            oper = qi.Pauli(pauli)
+            oper = qi.Operator(qi.Operator(qi.Pauli(pauli)))
 
             # CPTP channel test circuit
             channel = qi.random_quantum_channel(4, seed=SEED)

--- a/test/terra/reference/ref_measure.py
+++ b/test/terra/reference/ref_measure.py
@@ -73,6 +73,20 @@ def measure_circuits_deterministic(allow_sampling=True):
         circuit.i(qr)
     circuits.append(circuit)
 
+    # Measure a single qubit (qubit 1) in |1> state
+    qr = QuantumRegister(3)
+    cr = ClassicalRegister(1)
+    circuit = QuantumCircuit(qr, cr)
+    circuit.h(0)
+    circuit.x(1)
+    circuit.cx(0, 2)
+    circuit.barrier(qr)
+    circuit.measure(1, 0)
+    if not allow_sampling:
+        circuit.barrier(qr)
+        circuit.i(qr)
+    circuits.append(circuit)
+
     return circuits
 
 
@@ -89,6 +103,8 @@ def measure_counts_deterministic(shots, hex_counts=True):
         targets.append({'0x2': shots})
         # Measure |11> state
         targets.append({'0x3': shots})
+        # Measure a single qubit (qubit 1) in |1> state
+        targets.append({'0x1': shots})
     else:
         # Measure |00> state
         targets.append({'00': shots})
@@ -98,6 +114,9 @@ def measure_counts_deterministic(shots, hex_counts=True):
         targets.append({'10': shots})
         # Measure |11> state
         targets.append({'11': shots})
+        # Measure a single qubit (qubit 1) in |1> state
+        targets.append({'0x1': shots})
+
     return targets
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
I implemented optimized version of vector_ket for Thrust.

### Details and comments
It seems code base is older, so I merged with qiskit-aer/master.
However there are compilation errors  as following, caused by `save_data_pershot` function called from `Statevector::State::apply_save_statevector_ket`

`/qiskit-aer/src/framework/results/data/data.hpp(179): error: a nonstatic member reference must be relative to a specific object`

I have not tested my implementation because of this issue. 

